### PR TITLE
Implement realtime content surfaces and offline enhancements

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,51 @@
 // next.config.js
+const runtimeCaching = [
+    {
+        urlPattern: /^https?:\/\/res\.cloudinary\.com\/.*$/,
+        handler: "CacheFirst",
+        options: {
+            cacheName: "revanic-images",
+            expiration: { maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 * 30 },
+            cacheableResponse: { statuses: [0, 200] },
+        },
+    },
+    {
+        urlPattern: /^https?:\/\/fonts\.gstatic\.com\/.*$/,
+        handler: "CacheFirst",
+        options: {
+            cacheName: "revanic-fonts",
+            expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 365 },
+        },
+    },
+    {
+        urlPattern: ({ request }) => request.destination === "document" || request.destination === "script",
+        handler: "NetworkFirst",
+        options: {
+            cacheName: "revanic-pages",
+            networkTimeoutSeconds: 10,
+            expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 },
+        },
+    },
+    {
+        urlPattern: ({ url }) => url.pathname.startsWith("/api"),
+        handler: "NetworkFirst",
+        options: {
+            cacheName: "revanic-api",
+            networkTimeoutSeconds: 10,
+            expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 },
+        },
+    },
+];
+
 const withPWA = require("next-pwa")({
     dest: "public",
     register: true,
     skipWaiting: true,
-    disable: process.env.NODE_ENV === "development", // PWA را در حالت توسعه غیرفعال می‌کند
+    disable: process.env.NODE_ENV === "development",
+    runtimeCaching,
+    fallbacks: {
+        document: "/offline",
+    },
 });
 
 /** @type {import('next').NextConfig} */

--- a/src/app/api/admin/stats/stream/route.ts
+++ b/src/app/api/admin/stats/stream/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { getAdminDashboardStats } from "@/lib/admin/statsService";
+import { prisma } from "@/lib/prisma";
+
+const encoder = new TextEncoder();
+
+const sendEvent = (controller: ReadableStreamDefaultController, data: unknown) => {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+};
+
+export async function GET(request: Request) {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+    const userId = payload.userId as number;
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { role: true },
+    });
+
+    if (!user || user.role !== "ADMIN") {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
+
+    let active = true;
+    let interval: NodeJS.Timeout | undefined;
+    let lastPayload = "";
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        const pushStats = async (force = false) => {
+          const stats = await getAdminDashboardStats();
+          const serialized = JSON.stringify(stats);
+          if (force || serialized !== lastPayload) {
+            lastPayload = serialized;
+            sendEvent(controller, stats);
+          }
+        };
+
+        await pushStats(true);
+
+        interval = setInterval(() => {
+          if (!active) return;
+          pushStats();
+        }, 10000);
+
+        const abort = () => {
+          active = false;
+          if (interval) {
+            clearInterval(interval);
+          }
+          controller.close();
+        };
+
+        request.signal.addEventListener("abort", abort);
+      },
+      cancel() {
+        active = false;
+        if (interval) {
+          clearInterval(interval);
+        }
+      },
+    });
+
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    console.error("ADMIN_STATS_STREAM_ERROR", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { getNotificationsSnapshot } from "@/lib/notifications";
+
+const encoder = new TextEncoder();
+
+const sendEvent = (controller: ReadableStreamDefaultController, data: unknown) => {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+};
+
+export async function GET(request: Request) {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+    const userId = payload.userId as number;
+
+    let lastNotificationId: number | null = null;
+    let active = true;
+    let interval: NodeJS.Timeout | undefined;
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        const pushSnapshot = async () => {
+          const snapshot = await getNotificationsSnapshot(userId);
+          if (snapshot.notifications.length > 0) {
+            lastNotificationId = snapshot.notifications[0]?.id ?? lastNotificationId;
+          }
+          sendEvent(controller, snapshot);
+        };
+
+        await pushSnapshot();
+
+        interval = setInterval(async () => {
+          if (!active) return;
+          const snapshot = await getNotificationsSnapshot(userId);
+          const newestId = snapshot.notifications[0]?.id ?? null;
+          if (newestId && newestId !== lastNotificationId) {
+            lastNotificationId = newestId;
+            sendEvent(controller, snapshot);
+          }
+        }, 5000);
+
+        const abort = () => {
+          active = false;
+          clearInterval(interval);
+          controller.close();
+        };
+
+        request.signal.addEventListener("abort", abort);
+      },
+      cancel() {
+        active = false;
+        if (interval) {
+          clearInterval(interval);
+        }
+      },
+    });
+
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    console.error("NOTIFICATION_STREAM_ERROR", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,9 +1,9 @@
-"use client"; // اشتباه تایپی 'use-client' به "use client" اصلاح شد
-
-import { useState } from "react";
+// src/app/categories/page.tsx
+import { prisma } from "@/lib/prisma";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
 import {
   Laptop,
   History,
@@ -17,143 +17,149 @@ import {
   Leaf,
   BookOpen,
   Music,
+  LucideIcon,
 } from "lucide-react";
-import Link from "next/link";
-import Header from "@/components/Header";
-import Footer from "@/components/Footer";
 
-const Categories = () => {
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(
-    null
-  );
+type CategoryWithStats = {
+  id: number;
+  name: string;
+  slug: string;
+  description: string;
+  icon: LucideIcon;
+  color: string;
+  articleCount: number;
+};
 
-  const categories = [
-    {
-      id: "technology",
-      name: "فناوری",
-      icon: Laptop,
-      description: "آخرین اخبار و تحلیل‌های حوزه فناوری، هوش مصنوعی و نوآوری",
-      articleCount: 156,
-      color: "bg-blue-500",
-      featured: true,
-    },
-    {
-      id: "history",
-      name: "تاریخ",
-      icon: History,
-      description: "کاوش در تاریخ ایران و جهان، تمدن‌ها و وقایع مهم تاریخی",
-      articleCount: 89,
-      color: "bg-amber-500",
-      featured: true,
-    },
-    {
-      id: "art",
-      name: "هنر و معماری",
-      icon: Palette,
-      description: "هنر معاصر، معماری، طراحی و خلاقیت در ابعاد مختلف",
-      articleCount: 67,
-      color: "bg-purple-500",
-      featured: false,
-    },
-    {
-      id: "science",
-      name: "علم",
-      icon: FlaskConical,
-      description: "پیشرفت‌های علمی، تحقیقات جدید و کشفیات علمی",
-      articleCount: 98,
-      color: "bg-green-500",
-      featured: true,
-    },
-    {
-      id: "culture",
-      name: "فرهنگ",
-      icon: Globe,
-      description: "فرهنگ ایرانی و جهانی، آداب و رسوم، زندگی اجتماعی",
-      articleCount: 124,
-      color: "bg-rose-500",
-      featured: false,
-    },
-    {
-      id: "politics",
-      name: "سیاست",
-      icon: Building,
-      description: "تحلیل‌های سیاسی، رویدادهای داخلی و بین‌المللی",
-      articleCount: 78,
-      color: "bg-red-500",
-      featured: false,
-    },
-    {
-      id: "economy",
-      name: "اقتصاد",
-      icon: DollarSign,
-      description: "بازارهای مالی، اقتصاد ایران و جهان، استارتاپ‌ها",
-      articleCount: 92,
-      color: "bg-emerald-500",
-      featured: true,
-    },
-    {
-      id: "sports",
-      name: "ورزش",
-      icon: Dumbbell,
-      description: "اخبار ورزشی، تحلیل بازی‌ها و قهرمانان ورزشی",
-      articleCount: 45,
-      color: "bg-orange-500",
-      featured: false,
-    },
-    {
-      id: "health",
-      name: "سلامت",
-      icon: Heart,
-      description: "نکات سلامتی، پزشکی، تغذیه و سبک زندگی سالم",
-      articleCount: 73,
-      color: "bg-pink-500",
-      featured: false,
-    },
-    {
-      id: "environment",
-      name: "محیط زیست",
-      icon: Leaf,
-      description: "محیط زیست، تغییرات اقلیمی و حفاظت از طبیعت",
-      articleCount: 34,
-      color: "bg-teal-500",
-      featured: false,
-    },
-    {
-      id: "literature",
-      name: "ادبیات",
+const CATEGORY_METADATA: Record<string, { icon: LucideIcon; color: string; description: string }> = {
+  technology: {
+    icon: Laptop,
+    color: "bg-blue-500",
+    description: "آخرین نوآوری‌ها، هوش مصنوعی و آینده دنیای دیجیتال",
+  },
+  history: {
+    icon: History,
+    color: "bg-amber-500",
+    description: "سفر به گذشته و روایت تمدن‌های تاثیرگذار جهان",
+  },
+  art: {
+    icon: Palette,
+    color: "bg-purple-500",
+    description: "معماری، طراحی و الهامات خلاقانه هنرمندان",
+  },
+  science: {
+    icon: FlaskConical,
+    color: "bg-green-500",
+    description: "کشفیات تازه و تحلیل یافته‌های علمی",
+  },
+  culture: {
+    icon: Globe,
+    color: "bg-rose-500",
+    description: "جامعه، سبک زندگی و روایت‌های فرهنگی",
+  },
+  politics: {
+    icon: Building,
+    color: "bg-red-500",
+    description: "تحولات سیاسی ایران و جهان با نگاه تحلیلی",
+  },
+  economy: {
+    icon: DollarSign,
+    color: "bg-emerald-500",
+    description: "کسب‌وکارها، بازار سرمایه و اقتصاد هوشمند",
+  },
+  sports: {
+    icon: Dumbbell,
+    color: "bg-orange-500",
+    description: "اخبار، تحلیل مسابقات و پشت‌صحنه قهرمانان",
+  },
+  health: {
+    icon: Heart,
+    color: "bg-pink-500",
+    description: "پزشکی، تندرستی و سبک زندگی سالم",
+  },
+  environment: {
+    icon: Leaf,
+    color: "bg-teal-500",
+    description: "طبیعت، تغییرات اقلیمی و پایداری زیست‌بوم",
+  },
+  literature: {
+    icon: BookOpen,
+    color: "bg-indigo-500",
+    description: "کتاب‌ها، نقد ادبی و دنیای واژگان فارسی",
+  },
+  music: {
+    icon: Music,
+    color: "bg-violet-500",
+    description: "آهنگسازان، آلبوم‌های تازه و تحلیل سبک‌ها",
+  },
+};
+
+const FALLBACK_COLOR = "bg-slate-500";
+
+const createSlug = (name: string) =>
+  name
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^\u0600-\u06FF\w-]+/g, "");
+
+const getCategoryMetadata = (slug: string, name: string) => {
+  const fallbackDescription = `جدیدترین مقالات مرتبط با ${name}`;
+  const metadata = CATEGORY_METADATA[slug];
+
+  if (!metadata) {
+    return {
+      description: fallbackDescription,
       icon: BookOpen,
-      description: "شعر و ادب فارسی، نقد ادبی، کتاب‌خوانی",
-      articleCount: 87,
-      color: "bg-indigo-500",
-      featured: false,
-    },
-    {
-      id: "music",
-      name: "موسیقی",
-      icon: Music,
-      description: "موسیقی کلاسیک و مدرن، آموزش و تحلیل موسیقی",
-      articleCount: 29,
-      color: "bg-violet-500",
-      featured: false,
-    },
-  ];
+      color: FALLBACK_COLOR,
+    };
+  }
 
-  const featuredCategories = categories.filter((cat) => cat.featured);
-  const allCategories = categories;
+  return {
+    description: metadata.description,
+    icon: metadata.icon,
+    color: metadata.color,
+  };
+};
+
+const Categories = async () => {
+  const categoriesFromDb = await prisma.category.findMany({
+    orderBy: { name: "asc" },
+    include: {
+      articles: {
+        where: { status: "APPROVED" },
+        select: { id: true },
+      },
+    },
+  });
+
+  const categories: CategoryWithStats[] = categoriesFromDb.map((category) => {
+    const slug = createSlug(category.name);
+    const { color, description, icon } = getCategoryMetadata(slug, category.name);
+
+    return {
+      id: category.id,
+      name: category.name,
+      slug,
+      description,
+      icon,
+      color,
+      articleCount: category.articles.length,
+    };
+  });
+
+  const featuredCategories = [...categories]
+    .sort((a, b) => b.articleCount - a.articleCount)
+    .slice(0, 4);
 
   return (
     <div className="min-h-screen bg-background">
-
-
       {/* Hero Section */}
       <section className="py-16 bg-journal-cream/30">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
-            <h1 className="text-4xl font-bold text-journal mb-4">
-              دسته‌بندی مقالات
-            </h1>
+            <h1 className="text-4xl font-bold text-journal mb-4">دسته‌بندی مقالات</h1>
             <p className="text-xl text-journal-light mb-8">
-              موضوعات مختلف مجله روانیک را کاوش کنید
+              موضوعات مختلف مجله روانیک را با داده‌های زنده جست‌وجو کنید
             </p>
           </div>
         </div>
@@ -164,21 +170,19 @@ const Categories = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
             <h2 className="text-2xl font-bold text-journal mb-8 text-center">
-              دسته‌بندی‌های محبوب
+              پربازدیدترین موضوعات این هفته
             </h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
               {featuredCategories.map((category) => (
                 <Link
-                  href={`/articles?category=${category.id}`}
+                  href={`/articles?categoryId=${category.id}`}
                   key={category.id}
                 >
                   <Card className="group hover:shadow-medium transition-all duration-300 border-0 shadow-soft h-full">
                     <CardContent className="p-6 text-center">
                       <div className="flex justify-center mb-4">
-                        <div
-                          className={`p-4 ${category.color} text-white rounded-xl`}
-                        >
+                        <div className={`p-4 ${category.color} text-white rounded-xl`}>
                           <category.icon className="h-8 w-8" />
                         </div>
                       </div>
@@ -192,7 +196,7 @@ const Categories = () => {
                         variant="secondary"
                         className="bg-journal-cream text-journal-green"
                       >
-                        {category.articleCount} مقاله
+                        {category.articleCount.toLocaleString("fa-IR")} مقاله
                       </Badge>
                     </CardContent>
                   </Card>
@@ -208,21 +212,19 @@ const Categories = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
             <h2 className="text-2xl font-bold text-journal mb-8 text-center">
-              همه دسته‌بندی‌ها
+              همه موضوعات موجود
             </h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {allCategories.map((category) => (
+              {categories.map((category) => (
                 <Link
-                  href={`/articles?category=${category.id}`} // <-- 'to' به 'href' تغییر کرد
+                  href={`/articles?categoryId=${category.id}`}
                   key={category.id}
                 >
                   <Card className="group hover:shadow-medium transition-all duration-300 border-0 shadow-soft h-full">
                     <CardContent className="p-6">
                       <div className="flex items-start gap-4">
-                        <div
-                          className={`p-3 ${category.color} text-white rounded-lg flex-shrink-0`}
-                        >
+                        <div className={`p-3 ${category.color} text-white rounded-lg flex-shrink-0`}>
                           <category.icon className="h-6 w-6" />
                         </div>
                         <div className="flex-1">
@@ -237,16 +239,8 @@ const Categories = () => {
                               variant="secondary"
                               className="bg-journal-cream text-journal-green text-xs"
                             >
-                              {category.articleCount} مقاله
+                              {category.articleCount.toLocaleString("fa-IR")} مقاله
                             </Badge>
-                            {category.featured && (
-                              <Badge
-                                variant="outline"
-                                className="border-journal-orange text-journal-orange text-xs"
-                              >
-                                محبوب
-                              </Badge>
-                            )}
                           </div>
                         </div>
                       </div>
@@ -264,13 +258,13 @@ const Categories = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
             <h2 className="text-3xl font-bold text-journal mb-6">
-              موضوع مورد علاقه خود را پیدا نکردید؟
+              موضوع تازه‌ای مدنظر دارید؟
             </h2>
             <p className="text-xl text-journal-light mb-8">
-              پیشنهاد موضوع جدید دهید یا خودتان در آن حوزه مقاله بنویسید
+              به جمع نویسندگان بپیوندید یا پیشنهاد خود را برای ایجاد دسته‌بندی جدید ثبت کنید.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="/write"> {/* <-- 'to' به 'href' تغییر کرد */}
+              <Link href="/write">
                 <Button
                   size="lg"
                   className="bg-journal-green text-white hover:bg-journal-green-light"
@@ -278,7 +272,7 @@ const Categories = () => {
                   نوشتن مقاله
                 </Button>
               </Link>
-              <Link href="/contact"> {/* <-- 'to' به 'href' تغییر کرد */}
+              <Link href="/contact">
                 <Button
                   variant="outline"
                   size="lg"
@@ -291,7 +285,6 @@ const Categories = () => {
           </div>
         </div>
       </section>
-
     </div>
   );
 };

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,15 @@
+const OfflinePage = () => {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-journal-cream/40 text-center px-6">
+      <h1 className="text-3xl md:text-4xl font-bold text-journal mb-4">بدون اتصال اینترنت هستید</h1>
+      <p className="text-journal-light max-w-xl mb-8">
+        برای ادامه مطالعه به اینترنت متصل شوید. می‌توانید مقالات ذخیره شده در حافظه مرورگر را پس از اتصال مشاهده کنید.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        پس از برقراری اتصال، صفحه را تازه‌سازی کنید تا جدیدترین محتوا بارگذاری شود.
+      </p>
+    </div>
+  );
+};
+
+export default OfflinePage;

--- a/src/app/publications/page.tsx
+++ b/src/app/publications/page.tsx
@@ -1,93 +1,112 @@
-// src/app/publications/page.tsx
-'use client';
+import { prisma } from "@/lib/prisma";
+import { PublicationCard } from "@/components/PublicationCard";
+import { Card, CardContent } from "@/components/ui/card";
+import { Users, FileText, Sparkles } from "lucide-react";
 
-import { useQuery } from '@tanstack/react-query';
-import { PublicationCard } from '@/components/PublicationCard';
-import { Skeleton } from '@/components/ui/skeleton';
+const PublicationsPage = async () => {
+  const publications = await prisma.publication.findMany({
+    include: {
+      _count: { select: { members: true, articles: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
 
-interface Publication {
-    id: number;
-    name: string;
-    slug: string;
-    description: string | null;
-    avatarUrl: string | null;
-    _count: {
-        members: number;
-        articles: number;
-    };
-}
+  const totalPublications = publications.length;
+  const totalMembers = publications.reduce((sum, publication) => sum + publication._count.members, 0);
+  const totalArticles = publications.reduce((sum, publication) => sum + publication._count.articles, 0);
 
-// تابع برای دریافت لیست انتشارات از API
-const fetchPublications = async (): Promise<Publication[]> => {
-    const response = await fetch('/api/publications');
-    if (!response.ok) {
-        throw new Error('Failed to fetch publications');
-    }
-    return response.json();
-};
+  const featuredPublications = [...publications]
+    .sort((a, b) => b._count.articles - a._count.articles)
+    .slice(0, 3);
 
-const PublicationsPage = () => {
-    const { data: publications, isLoading, isError } = useQuery<Publication[]>({
-        queryKey: ['publications'],
-        queryFn: fetchPublications,
-    });
-
-    return (
-        <div className="min-h-screen bg-background">
-            <section className="py-16 bg-muted/20">
-                <div className="container mx-auto px-4">
-                    <div className="max-w-4xl mx-auto text-center">
-                        <h1 className="text-4xl font-bold text-foreground mb-4">
-                            انتشارات روانیک
-                        </h1>
-                        <p className="text-xl text-muted-foreground">
-                            مجموعه‌ای از بهترین مجلات تخصصی فارسی را دنبال کنید.
-                        </p>
-                    </div>
-                </div>
-            </section>
-
-            <section className="py-12">
-                <div className="container mx-auto px-4">
-                    <div className="max-w-6xl mx-auto">
-                        {isLoading ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                {[...Array(4)].map((_, i) => (
-                                    <Skeleton key={i} className="h-48 w-full" />
-                                ))}
-                            </div>
-                        ) : isError ? (
-                            <div className="text-center py-12">
-                                <p className="text-destructive text-lg">
-                                    خطا در دریافت اطلاعات. لطفاً دوباره تلاش کنید.
-                                </p>
-                            </div>
-                        ) : publications && publications.length > 0 ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                {publications.map((pub) => (
-                                    <PublicationCard
-                                        key={pub.id}
-                                        name={pub.name}
-                                        slug={pub.slug}
-                                        description={pub.description}
-                                        avatarUrl={pub.avatarUrl}
-                                        membersCount={pub._count.members}
-                                        articlesCount={pub._count.articles}
-                                    />
-                                ))}
-                            </div>
-                        ) : (
-                            <div className="text-center py-12">
-                                <p className="text-muted-foreground text-lg">
-                                    هنوز هیچ انتشاراتی ثبت نشده است.
-                                </p>
-                            </div>
-                        )}
-                    </div>
-                </div>
-            </section>
+  return (
+    <div className="min-h-screen bg-background">
+      <section className="py-16 bg-muted/20">
+        <div className="container mx-auto px-4">
+          <div className="max-w-5xl mx-auto text-center space-y-6">
+            <h1 className="text-4xl font-bold text-foreground">انتشارات روانیک</h1>
+            <p className="text-lg text-muted-foreground">
+              از نشریات تخصصی و جمعی روانیک بازدید کنید و با نویسندگان حرفه‌ای همکاری داشته باشید.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <Card className="border-0 shadow-soft">
+                <CardContent className="flex flex-col items-center gap-2 py-6">
+                  <Users className="h-8 w-8 text-journal-green" />
+                  <p className="text-sm text-muted-foreground">کل اعضای فعال</p>
+                  <span className="text-2xl font-bold">{totalMembers.toLocaleString("fa-IR")}</span>
+                </CardContent>
+              </Card>
+              <Card className="border-0 shadow-soft">
+                <CardContent className="flex flex-col items-center gap-2 py-6">
+                  <FileText className="h-8 w-8 text-journal-orange" />
+                  <p className="text-sm text-muted-foreground">مجموع مقالات منتشر شده</p>
+                  <span className="text-2xl font-bold">{totalArticles.toLocaleString("fa-IR")}</span>
+                </CardContent>
+              </Card>
+              <Card className="border-0 shadow-soft">
+                <CardContent className="flex flex-col items-center gap-2 py-6">
+                  <Sparkles className="h-8 w-8 text-journal" />
+                  <p className="text-sm text-muted-foreground">تعداد نشریات فعال</p>
+                  <span className="text-2xl font-bold">{totalPublications.toLocaleString("fa-IR")}</span>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
         </div>
-    );
+      </section>
+
+      {featuredPublications.length > 0 && (
+        <section className="py-12">
+          <div className="container mx-auto px-4">
+            <div className="max-w-5xl mx-auto">
+              <h2 className="text-2xl font-bold text-foreground mb-6 text-center">نشریات پیشنهادی</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {featuredPublications.map((publication) => (
+                  <PublicationCard
+                    key={publication.id}
+                    name={publication.name}
+                    slug={publication.slug}
+                    description={publication.description}
+                    avatarUrl={publication.avatarUrl}
+                    membersCount={publication._count.members}
+                    articlesCount={publication._count.articles}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="py-12">
+        <div className="container mx-auto px-4">
+          <div className="max-w-6xl mx-auto">
+            {publications.length > 0 ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {publications.map((publication) => (
+                  <PublicationCard
+                    key={publication.id}
+                    name={publication.name}
+                    slug={publication.slug}
+                    description={publication.description}
+                    avatarUrl={publication.avatarUrl}
+                    membersCount={publication._count.members}
+                    articlesCount={publication._count.articles}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-12">
+                <p className="text-muted-foreground text-lg">
+                  هنوز هیچ انتشاراتی ثبت نشده است.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
 };
 
 export default PublicationsPage;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,17 @@
+import { prisma } from "@/lib/prisma";
+
+export async function getNotificationsSnapshot(userId: number) {
+  const [notifications, unreadCount] = await Promise.all([
+    prisma.notification.findMany({
+      where: { userId },
+      include: {
+        actor: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    }),
+    prisma.notification.count({ where: { userId, isRead: false } }),
+  ]);
+
+  return { notifications, unreadCount };
+}

--- a/src/lib/reading-history.ts
+++ b/src/lib/reading-history.ts
@@ -1,0 +1,104 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+type RangeOption = "7d" | "30d" | "90d" | "365d" | "all";
+
+export interface ReadingHistoryFilters {
+  search?: string;
+  range?: RangeOption;
+  categoryId?: number;
+  limit?: number;
+}
+
+export interface ReadingHistoryEntry {
+  viewedAt: Date;
+  article: Prisma.ArticleGetPayload<{
+    include: {
+      author: { select: { name: true; avatarUrl: true } };
+      categories: { select: { name: true } };
+      _count: { select: { claps: true; comments: true } };
+    };
+  }>;
+}
+
+const resolveRange = (range?: RangeOption) => {
+  switch (range) {
+    case "7d":
+      return 7;
+    case "30d":
+      return 30;
+    case "90d":
+      return 90;
+    case "365d":
+      return 365;
+    default:
+      return undefined;
+  }
+};
+
+export async function getReadingHistoryEntries(
+  userId: number,
+  { search, range = "30d", categoryId, limit = 50 }: ReadingHistoryFilters = {}
+): Promise<ReadingHistoryEntry[]> {
+  const normalizedLimit = Math.min(Math.max(limit, 1), 200);
+  const days = resolveRange(range);
+
+  const where: Prisma.ReadingHistoryWhereInput = {
+    userId,
+  };
+
+  if (days) {
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+    where.viewedAt = { gte: since };
+  }
+
+  const articleFilters: Prisma.ArticleWhereInput = {};
+
+  if (search) {
+    const normalizedSearch = search.trim();
+    if (normalizedSearch.length > 0) {
+      articleFilters.OR = [
+        { title: { contains: normalizedSearch, mode: "insensitive" } },
+        { content: { contains: normalizedSearch, mode: "insensitive" } },
+        {
+          categories: {
+            some: { name: { contains: normalizedSearch, mode: "insensitive" } },
+          },
+        },
+      ];
+    }
+  }
+
+  if (categoryId) {
+    articleFilters.categories = {
+      some: { id: categoryId },
+    };
+  }
+
+  if (Object.keys(articleFilters).length > 0) {
+    where.article = {
+      ...articleFilters,
+    };
+  }
+
+  const history = await prisma.readingHistory.findMany({
+    where,
+    orderBy: { viewedAt: "desc" },
+    take: normalizedLimit,
+    include: {
+      article: {
+        include: {
+          author: { select: { name: true, avatarUrl: true } },
+          categories: { select: { name: true } },
+          _count: { select: { claps: true, comments: true } },
+        },
+      },
+    },
+  });
+
+  return history.map((entry) => ({
+    viewedAt: entry.viewedAt,
+    article: entry.article,
+  }));
+}


### PR DESCRIPTION
## Summary
- feed the homepage and categories pages from Prisma data and allow article filtering by category
- expand the profile reading history with server-side filters, CSV export, and helper utilities
- stream notifications and admin dashboard stats over SSE and enhance publications plus PWA offline caching

## Testing
- npm run lint *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e12e9482a08332b1c5991f624d8ec7