### PR TITLE
Add support ticket workflow

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,51 @@
 // next.config.js
+const runtimeCaching = [
+    {
+        urlPattern: /^https?:\/\/res\.cloudinary\.com\/.*$/,
+        handler: "CacheFirst",
+        options: {
+            cacheName: "revanic-images",
+            expiration: { maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 * 30 },
+            cacheableResponse: { statuses: [0, 200] },
+        },
+    },
+    {
+        urlPattern: /^https?:\/\/fonts\.gstatic\.com\/.*$/,
+        handler: "CacheFirst",
+        options: {
+            cacheName: "revanic-fonts",
+            expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 365 },
+        },
+    },
+    {
+        urlPattern: ({ request }) => request.destination === "document" || request.destination === "script",
+        handler: "NetworkFirst",
+        options: {
+            cacheName: "revanic-pages",
+            networkTimeoutSeconds: 10,
+            expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 },
+        },
+    },
+    {
+        urlPattern: ({ url }) => url.pathname.startsWith("/api"),
+        handler: "NetworkFirst",
+        options: {
+            cacheName: "revanic-api",
+            networkTimeoutSeconds: 10,
+            expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 },
+        },
+    },
+];
+
 const withPWA = require("next-pwa")({
     dest: "public",
     register: true,
     skipWaiting: true,
-    disable: process.env.NODE_ENV === "development", // PWA را در حالت توسعه غیرفعال می‌کند
+    disable: process.env.NODE_ENV === "development",
+    runtimeCaching,
+    fallbacks: {
+        document: "/offline",
+    },
 });
 
 /** @type {import('next').NextConfig} */

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,9 +34,11 @@ model User {
   updatedAt              DateTime       @updatedAt
   publications           UsersOnPublications[]
   highlights             Highlight[]
-  
+
   // --- فیلد جدید برای تاریخچه مطالعه ---
   readingHistory         ReadingHistory[]
+  supportTickets         SupportTicket[]
+  supportMessages        SupportMessage[] @relation("SupportMessageAuthor")
 }
 
 model Article {
@@ -66,6 +68,39 @@ model Article {
 
   // --- فیلد جدید برای تاریخچه مطالعه ---
   history       ReadingHistory[]
+}
+
+model SupportTicket {
+  id        Int                   @id @default(autoincrement())
+  title     String
+  status    SupportTicketStatus   @default(OPEN)
+  user      User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    Int
+  messages  SupportMessage[]
+  createdAt DateTime              @default(now())
+  updatedAt DateTime              @updatedAt
+}
+
+model SupportMessage {
+  id         Int                      @id @default(autoincrement())
+  body       String
+  authorRole SupportMessageAuthorRole
+  ticket     SupportTicket            @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  ticketId   Int
+  author     User?                    @relation("SupportMessageAuthor", fields: [authorId], references: [id], onDelete: SetNull)
+  authorId   Int?
+  createdAt  DateTime                 @default(now())
+}
+
+enum SupportTicketStatus {
+  OPEN
+  ANSWERED
+  CLOSED
+}
+
+enum SupportMessageAuthorRole {
+  USER
+  ADMIN
 }
 
 model Publication {

--- a/src/app/api/admin/stats/stream/route.ts
+++ b/src/app/api/admin/stats/stream/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { getAdminDashboardStats } from "@/lib/admin/statsService";
+import { prisma } from "@/lib/prisma";
+
+const encoder = new TextEncoder();
+
+const sendEvent = (controller: ReadableStreamDefaultController, data: unknown) => {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+};
+
+export async function GET(request: Request) {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+    const userId = payload.userId as number;
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { role: true },
+    });
+
+    if (!user || user.role !== "ADMIN") {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
+
+    let active = true;
+    let interval: NodeJS.Timeout | undefined;
+    let lastPayload = "";
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        const pushStats = async (force = false) => {
+          const stats = await getAdminDashboardStats();
+          const serialized = JSON.stringify(stats);
+          if (force || serialized !== lastPayload) {
+            lastPayload = serialized;
+            sendEvent(controller, stats);
+          }
+        };
+
+        await pushStats(true);
+
+        interval = setInterval(() => {
+          if (!active) return;
+          pushStats();
+        }, 10000);
+
+        const abort = () => {
+          active = false;
+          if (interval) {
+            clearInterval(interval);
+          }
+          controller.close();
+        };
+
+        request.signal.addEventListener("abort", abort);
+      },
+      cancel() {
+        active = false;
+        if (interval) {
+          clearInterval(interval);
+        }
+      },
+    });
+
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    console.error("ADMIN_STATS_STREAM_ERROR", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/api/admin/support/tickets/[id]/reply/route.ts
+++ b/src/app/api/admin/support/tickets/[id]/reply/route.ts
@@ -1,0 +1,150 @@
+// src/app/api/admin/support/tickets/[id]/reply/route.ts
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { prisma } from "@/lib/prisma";
+import type { Prisma, SupportTicketStatus } from "@prisma/client";
+
+const statusTexts = {
+  OPEN: "در انتظار پاسخ",
+  ANSWERED: "پاسخ داده شده",
+  CLOSED: "بسته شده",
+};
+
+const allowedStatuses: SupportTicketStatus[] = ["OPEN", "ANSWERED", "CLOSED"];
+
+interface AdminPayload {
+  userId?: number;
+  role?: string;
+}
+
+async function requireAdmin() {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+    const adminPayload = payload as AdminPayload;
+    if (adminPayload.role === "ADMIN" && typeof adminPayload.userId === "number") {
+      return adminPayload.userId;
+    }
+    return null;
+  } catch (error) {
+    console.error("ADMIN_SUPPORT_REPLY_AUTH_ERROR", error);
+    return null;
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const adminId = await requireAdmin();
+  if (!adminId) {
+    return NextResponse.json({ message: "دسترسی غیرمجاز." }, { status: 403 });
+  }
+
+  const ticketId = Number(params.id);
+  if (!ticketId || Number.isNaN(ticketId)) {
+    return NextResponse.json({ message: "شناسه تیکت نامعتبر است." }, { status: 400 });
+  }
+
+  try {
+    const body = await request.json();
+    const message: string | undefined = body?.message?.trim();
+    const status = body?.status as SupportTicketStatus | undefined;
+
+    if (!message && !status) {
+      return NextResponse.json(
+        { message: "لطفاً متن پاسخ یا وضعیت جدید را ارسال کنید." },
+        { status: 400 }
+      );
+    }
+
+    if (status && !allowedStatuses.includes(status)) {
+      return NextResponse.json(
+        { message: "وضعیت انتخاب شده معتبر نیست." },
+        { status: 400 }
+      );
+    }
+
+    const ticketExists = await prisma.supportTicket.findUnique({
+      where: { id: ticketId },
+      select: { id: true },
+    });
+
+    if (!ticketExists) {
+      return NextResponse.json(
+        { message: "تیکت مورد نظر یافت نشد." },
+        { status: 404 }
+      );
+    }
+
+    await prisma.$transaction(async (tx) => {
+      if (message) {
+        await tx.supportMessage.create({
+          data: {
+            ticketId,
+            body: message,
+            authorRole: "ADMIN",
+            authorId: adminId,
+          },
+        });
+      }
+
+      const updateData: Prisma.SupportTicketUpdateInput = {
+        updatedAt: new Date(),
+      };
+
+      if (status) {
+        updateData.status = status;
+      }
+
+      await tx.supportTicket.update({
+        where: { id: ticketId },
+        data: updateData,
+      });
+    });
+
+    const refreshedTicket = await prisma.supportTicket.findUnique({
+      where: { id: ticketId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            avatarUrl: true,
+          },
+        },
+        messages: {
+          orderBy: { createdAt: "asc" },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                role: true,
+                avatarUrl: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({
+      ...refreshedTicket,
+      statusLabel: refreshedTicket ? statusTexts[refreshedTicket.status] : undefined,
+    });
+  } catch (error) {
+    console.error("ADMIN_SUPPORT_REPLY_ERROR", error);
+    return NextResponse.json(
+      { message: "ارسال پاسخ با خطا مواجه شد." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/support/tickets/route.ts
+++ b/src/app/api/admin/support/tickets/route.ts
@@ -1,0 +1,85 @@
+// src/app/api/admin/support/tickets/route.ts
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { prisma } from "@/lib/prisma";
+
+const statusTexts = {
+  OPEN: "در انتظار پاسخ",
+  ANSWERED: "پاسخ داده شده",
+  CLOSED: "بسته شده",
+};
+
+interface AdminPayload {
+  userId?: number;
+  role?: string;
+}
+
+async function requireAdmin() {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+    const adminPayload = payload as AdminPayload;
+    if (adminPayload.role === "ADMIN" && typeof adminPayload.userId === "number") {
+      return adminPayload.userId;
+    }
+    return null;
+  } catch (error) {
+    console.error("ADMIN_SUPPORT_AUTH_ERROR", error);
+    return null;
+  }
+}
+
+export async function GET() {
+  const adminId = await requireAdmin();
+  if (!adminId) {
+    return NextResponse.json({ message: "دسترسی غیرمجاز." }, { status: 403 });
+  }
+
+  try {
+    const tickets = await prisma.supportTicket.findMany({
+      orderBy: { createdAt: "desc" },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            avatarUrl: true,
+          },
+        },
+        messages: {
+          orderBy: { createdAt: "asc" },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                role: true,
+                avatarUrl: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(
+      tickets.map((ticket) => ({
+        ...ticket,
+        statusLabel: statusTexts[ticket.status],
+      }))
+    );
+  } catch (error) {
+    console.error("ADMIN_SUPPORT_FETCH_ERROR", error);
+    return NextResponse.json(
+      { message: "خطا در دریافت تیکت‌های پشتیبانی." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { getNotificationsSnapshot } from "@/lib/notifications";
+
+const encoder = new TextEncoder();
+
+const sendEvent = (controller: ReadableStreamDefaultController, data: unknown) => {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+};
+
+export async function GET(request: Request) {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+    const userId = payload.userId as number;
+
+    let lastNotificationId: number | null = null;
+    let active = true;
+    let interval: NodeJS.Timeout | undefined;
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        const pushSnapshot = async () => {
+          const snapshot = await getNotificationsSnapshot(userId);
+          if (snapshot.notifications.length > 0) {
+            lastNotificationId = snapshot.notifications[0]?.id ?? lastNotificationId;
+          }
+          sendEvent(controller, snapshot);
+        };
+
+        await pushSnapshot();
+
+        interval = setInterval(async () => {
+          if (!active) return;
+          const snapshot = await getNotificationsSnapshot(userId);
+          const newestId = snapshot.notifications[0]?.id ?? null;
+          if (newestId && newestId !== lastNotificationId) {
+            lastNotificationId = newestId;
+            sendEvent(controller, snapshot);
+          }
+        }, 5000);
+
+        const abort = () => {
+          active = false;
+          clearInterval(interval);
+          controller.close();
+        };
+
+        request.signal.addEventListener("abort", abort);
+      },
+      cancel() {
+        active = false;
+        if (interval) {
+          clearInterval(interval);
+        }
+      },
+    });
+
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    console.error("NOTIFICATION_STREAM_ERROR", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/api/support/tickets/route.ts
+++ b/src/app/api/support/tickets/route.ts
@@ -1,0 +1,145 @@
+// src/app/api/support/tickets/route.ts
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { prisma } from "@/lib/prisma";
+
+const statusTexts = {
+  OPEN: "در انتظار پاسخ",
+  ANSWERED: "پاسخ داده شده",
+  CLOSED: "بسته شده",
+};
+
+async function getAuthenticatedUserId() {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+    return typeof payload.userId === "number" ? payload.userId : null;
+  } catch (error) {
+    console.error("SUPPORT_TICKETS_AUTH_ERROR", error);
+    return null;
+  }
+}
+
+export async function GET() {
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json(
+      { message: "دسترسی غیرمجاز." },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const tickets = await prisma.supportTicket.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      include: {
+        messages: {
+          orderBy: { createdAt: "asc" },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                role: true,
+                avatarUrl: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(
+      tickets.map((ticket) => ({
+        ...ticket,
+        statusLabel: statusTexts[ticket.status],
+      }))
+    );
+  } catch (error) {
+    console.error("SUPPORT_TICKETS_FETCH_ERROR", error);
+    return NextResponse.json(
+      { message: "خطا در دریافت تیکت‌ها." },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json(
+      { message: "دسترسی غیرمجاز." },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const title: string = body?.title;
+    const message: string = body?.message;
+
+    if (!title || !title.trim()) {
+      return NextResponse.json(
+        { message: "عنوان تیکت نمی‌تواند خالی باشد." },
+        { status: 400 }
+      );
+    }
+
+    if (!message || !message.trim()) {
+      return NextResponse.json(
+        { message: "متن پیام نمی‌تواند خالی باشد." },
+        { status: 400 }
+      );
+    }
+
+    const ticket = await prisma.supportTicket.create({
+      data: {
+        title: title.trim(),
+        userId,
+        messages: {
+          create: {
+            body: message.trim(),
+            authorId: userId,
+            authorRole: "USER",
+          },
+        },
+      },
+      include: {
+        messages: {
+          orderBy: { createdAt: "asc" },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                role: true,
+                avatarUrl: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(
+      {
+        ...ticket,
+        statusLabel: statusTexts[ticket.status],
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("SUPPORT_TICKETS_CREATE_ERROR", error);
+    return NextResponse.json(
+      { message: "در ثبت تیکت خطایی رخ داد." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,9 +1,9 @@
-"use client"; // اشتباه تایپی 'use-client' به "use client" اصلاح شد
-
-import { useState } from "react";
+// src/app/categories/page.tsx
+import { prisma } from "@/lib/prisma";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
 import {
   Laptop,
   History,
@@ -17,143 +17,149 @@ import {
   Leaf,
   BookOpen,
   Music,
+  LucideIcon,
 } from "lucide-react";
-import Link from "next/link";
-import Header from "@/components/Header";
-import Footer from "@/components/Footer";
 
-const Categories = () => {
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(
-    null
-  );
+type CategoryWithStats = {
+  id: number;
+  name: string;
+  slug: string;
+  description: string;
+  icon: LucideIcon;
+  color: string;
+  articleCount: number;
+};
 
-  const categories = [
-    {
-      id: "technology",
-      name: "فناوری",
-      icon: Laptop,
-      description: "آخرین اخبار و تحلیل‌های حوزه فناوری، هوش مصنوعی و نوآوری",
-      articleCount: 156,
-      color: "bg-blue-500",
-      featured: true,
-    },
-    {
-      id: "history",
-      name: "تاریخ",
-      icon: History,
-      description: "کاوش در تاریخ ایران و جهان، تمدن‌ها و وقایع مهم تاریخی",
-      articleCount: 89,
-      color: "bg-amber-500",
-      featured: true,
-    },
-    {
-      id: "art",
-      name: "هنر و معماری",
-      icon: Palette,
-      description: "هنر معاصر، معماری، طراحی و خلاقیت در ابعاد مختلف",
-      articleCount: 67,
-      color: "bg-purple-500",
-      featured: false,
-    },
-    {
-      id: "science",
-      name: "علم",
-      icon: FlaskConical,
-      description: "پیشرفت‌های علمی، تحقیقات جدید و کشفیات علمی",
-      articleCount: 98,
-      color: "bg-green-500",
-      featured: true,
-    },
-    {
-      id: "culture",
-      name: "فرهنگ",
-      icon: Globe,
-      description: "فرهنگ ایرانی و جهانی، آداب و رسوم، زندگی اجتماعی",
-      articleCount: 124,
-      color: "bg-rose-500",
-      featured: false,
-    },
-    {
-      id: "politics",
-      name: "سیاست",
-      icon: Building,
-      description: "تحلیل‌های سیاسی، رویدادهای داخلی و بین‌المللی",
-      articleCount: 78,
-      color: "bg-red-500",
-      featured: false,
-    },
-    {
-      id: "economy",
-      name: "اقتصاد",
-      icon: DollarSign,
-      description: "بازارهای مالی، اقتصاد ایران و جهان، استارتاپ‌ها",
-      articleCount: 92,
-      color: "bg-emerald-500",
-      featured: true,
-    },
-    {
-      id: "sports",
-      name: "ورزش",
-      icon: Dumbbell,
-      description: "اخبار ورزشی، تحلیل بازی‌ها و قهرمانان ورزشی",
-      articleCount: 45,
-      color: "bg-orange-500",
-      featured: false,
-    },
-    {
-      id: "health",
-      name: "سلامت",
-      icon: Heart,
-      description: "نکات سلامتی، پزشکی، تغذیه و سبک زندگی سالم",
-      articleCount: 73,
-      color: "bg-pink-500",
-      featured: false,
-    },
-    {
-      id: "environment",
-      name: "محیط زیست",
-      icon: Leaf,
-      description: "محیط زیست، تغییرات اقلیمی و حفاظت از طبیعت",
-      articleCount: 34,
-      color: "bg-teal-500",
-      featured: false,
-    },
-    {
-      id: "literature",
-      name: "ادبیات",
+const CATEGORY_METADATA: Record<string, { icon: LucideIcon; color: string; description: string }> = {
+  technology: {
+    icon: Laptop,
+    color: "bg-blue-500",
+    description: "آخرین نوآوری‌ها، هوش مصنوعی و آینده دنیای دیجیتال",
+  },
+  history: {
+    icon: History,
+    color: "bg-amber-500",
+    description: "سفر به گذشته و روایت تمدن‌های تاثیرگذار جهان",
+  },
+  art: {
+    icon: Palette,
+    color: "bg-purple-500",
+    description: "معماری، طراحی و الهامات خلاقانه هنرمندان",
+  },
+  science: {
+    icon: FlaskConical,
+    color: "bg-green-500",
+    description: "کشفیات تازه و تحلیل یافته‌های علمی",
+  },
+  culture: {
+    icon: Globe,
+    color: "bg-rose-500",
+    description: "جامعه، سبک زندگی و روایت‌های فرهنگی",
+  },
+  politics: {
+    icon: Building,
+    color: "bg-red-500",
+    description: "تحولات سیاسی ایران و جهان با نگاه تحلیلی",
+  },
+  economy: {
+    icon: DollarSign,
+    color: "bg-emerald-500",
+    description: "کسب‌وکارها، بازار سرمایه و اقتصاد هوشمند",
+  },
+  sports: {
+    icon: Dumbbell,
+    color: "bg-orange-500",
+    description: "اخبار، تحلیل مسابقات و پشت‌صحنه قهرمانان",
+  },
+  health: {
+    icon: Heart,
+    color: "bg-pink-500",
+    description: "پزشکی، تندرستی و سبک زندگی سالم",
+  },
+  environment: {
+    icon: Leaf,
+    color: "bg-teal-500",
+    description: "طبیعت، تغییرات اقلیمی و پایداری زیست‌بوم",
+  },
+  literature: {
+    icon: BookOpen,
+    color: "bg-indigo-500",
+    description: "کتاب‌ها، نقد ادبی و دنیای واژگان فارسی",
+  },
+  music: {
+    icon: Music,
+    color: "bg-violet-500",
+    description: "آهنگسازان، آلبوم‌های تازه و تحلیل سبک‌ها",
+  },
+};
+
+const FALLBACK_COLOR = "bg-slate-500";
+
+const createSlug = (name: string) =>
+  name
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^\u0600-\u06FF\w-]+/g, "");
+
+const getCategoryMetadata = (slug: string, name: string) => {
+  const fallbackDescription = `جدیدترین مقالات مرتبط با ${name}`;
+  const metadata = CATEGORY_METADATA[slug];
+
+  if (!metadata) {
+    return {
+      description: fallbackDescription,
       icon: BookOpen,
-      description: "شعر و ادب فارسی، نقد ادبی، کتاب‌خوانی",
-      articleCount: 87,
-      color: "bg-indigo-500",
-      featured: false,
-    },
-    {
-      id: "music",
-      name: "موسیقی",
-      icon: Music,
-      description: "موسیقی کلاسیک و مدرن، آموزش و تحلیل موسیقی",
-      articleCount: 29,
-      color: "bg-violet-500",
-      featured: false,
-    },
-  ];
+      color: FALLBACK_COLOR,
+    };
+  }
 
-  const featuredCategories = categories.filter((cat) => cat.featured);
-  const allCategories = categories;
+  return {
+    description: metadata.description,
+    icon: metadata.icon,
+    color: metadata.color,
+  };
+};
+
+const Categories = async () => {
+  const categoriesFromDb = await prisma.category.findMany({
+    orderBy: { name: "asc" },
+    include: {
+      articles: {
+        where: { status: "APPROVED" },
+        select: { id: true },
+      },
+    },
+  });
+
+  const categories: CategoryWithStats[] = categoriesFromDb.map((category) => {
+    const slug = createSlug(category.name);
+    const { color, description, icon } = getCategoryMetadata(slug, category.name);
+
+    return {
+      id: category.id,
+      name: category.name,
+      slug,
+      description,
+      icon,
+      color,
+      articleCount: category.articles.length,
+    };
+  });
+
+  const featuredCategories = [...categories]
+    .sort((a, b) => b.articleCount - a.articleCount)
+    .slice(0, 4);
 
   return (
     <div className="min-h-screen bg-background">
-
-
       {/* Hero Section */}
       <section className="py-16 bg-journal-cream/30">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
-            <h1 className="text-4xl font-bold text-journal mb-4">
-              دسته‌بندی مقالات
-            </h1>
+            <h1 className="text-4xl font-bold text-journal mb-4">دسته‌بندی مقالات</h1>
             <p className="text-xl text-journal-light mb-8">
-              موضوعات مختلف مجله روانیک را کاوش کنید
+              موضوعات مختلف مجله روانیک را با داده‌های زنده جست‌وجو کنید
             </p>
           </div>
         </div>
@@ -164,21 +170,19 @@ const Categories = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
             <h2 className="text-2xl font-bold text-journal mb-8 text-center">
-              دسته‌بندی‌های محبوب
+              پربازدیدترین موضوعات این هفته
             </h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
               {featuredCategories.map((category) => (
                 <Link
-                  href={`/articles?category=${category.id}`}
+                  href={`/articles?categoryId=${category.id}`}
                   key={category.id}
                 >
                   <Card className="group hover:shadow-medium transition-all duration-300 border-0 shadow-soft h-full">
                     <CardContent className="p-6 text-center">
                       <div className="flex justify-center mb-4">
-                        <div
-                          className={`p-4 ${category.color} text-white rounded-xl`}
-                        >
+                        <div className={`p-4 ${category.color} text-white rounded-xl`}>
                           <category.icon className="h-8 w-8" />
                         </div>
                       </div>
@@ -192,7 +196,7 @@ const Categories = () => {
                         variant="secondary"
                         className="bg-journal-cream text-journal-green"
                       >
-                        {category.articleCount} مقاله
+                        {category.articleCount.toLocaleString("fa-IR")} مقاله
                       </Badge>
                     </CardContent>
                   </Card>
@@ -208,21 +212,19 @@ const Categories = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
             <h2 className="text-2xl font-bold text-journal mb-8 text-center">
-              همه دسته‌بندی‌ها
+              همه موضوعات موجود
             </h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {allCategories.map((category) => (
+              {categories.map((category) => (
                 <Link
-                  href={`/articles?category=${category.id}`} // <-- 'to' به 'href' تغییر کرد
+                  href={`/articles?categoryId=${category.id}`}
                   key={category.id}
                 >
                   <Card className="group hover:shadow-medium transition-all duration-300 border-0 shadow-soft h-full">
                     <CardContent className="p-6">
                       <div className="flex items-start gap-4">
-                        <div
-                          className={`p-3 ${category.color} text-white rounded-lg flex-shrink-0`}
-                        >
+                        <div className={`p-3 ${category.color} text-white rounded-lg flex-shrink-0`}>
                           <category.icon className="h-6 w-6" />
                         </div>
                         <div className="flex-1">
@@ -237,16 +239,8 @@ const Categories = () => {
                               variant="secondary"
                               className="bg-journal-cream text-journal-green text-xs"
                             >
-                              {category.articleCount} مقاله
+                              {category.articleCount.toLocaleString("fa-IR")} مقاله
                             </Badge>
-                            {category.featured && (
-                              <Badge
-                                variant="outline"
-                                className="border-journal-orange text-journal-orange text-xs"
-                              >
-                                محبوب
-                              </Badge>
-                            )}
                           </div>
                         </div>
                       </div>
@@ -264,13 +258,13 @@ const Categories = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
             <h2 className="text-3xl font-bold text-journal mb-6">
-              موضوع مورد علاقه خود را پیدا نکردید؟
+              موضوع تازه‌ای مدنظر دارید؟
             </h2>
             <p className="text-xl text-journal-light mb-8">
-              پیشنهاد موضوع جدید دهید یا خودتان در آن حوزه مقاله بنویسید
+              به جمع نویسندگان بپیوندید یا پیشنهاد خود را برای ایجاد دسته‌بندی جدید ثبت کنید.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="/write"> {/* <-- 'to' به 'href' تغییر کرد */}
+              <Link href="/write">
                 <Button
                   size="lg"
                   className="bg-journal-green text-white hover:bg-journal-green-light"
@@ -278,7 +272,7 @@ const Categories = () => {
                   نوشتن مقاله
                 </Button>
               </Link>
-              <Link href="/contact"> {/* <-- 'to' به 'href' تغییر کرد */}
+              <Link href="/contact">
                 <Button
                   variant="outline"
                   size="lg"
@@ -291,7 +285,6 @@ const Categories = () => {
           </div>
         </div>
       </section>
-
     </div>
   );
 };

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,15 @@
+const OfflinePage = () => {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-journal-cream/40 text-center px-6">
+      <h1 className="text-3xl md:text-4xl font-bold text-journal mb-4">بدون اتصال اینترنت هستید</h1>
+      <p className="text-journal-light max-w-xl mb-8">
+        برای ادامه مطالعه به اینترنت متصل شوید. می‌توانید مقالات ذخیره شده در حافظه مرورگر را پس از اتصال مشاهده کنید.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        پس از برقراری اتصال، صفحه را تازه‌سازی کنید تا جدیدترین محتوا بارگذاری شود.
+      </p>
+    </div>
+  );
+};
+
+export default OfflinePage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,50 +1,70 @@
 // src/app/page.tsx
+import { prisma } from "@/lib/prisma";
 import { Button } from "@/components/ui/button";
 import { PenTool, BookOpen, Users } from "lucide-react";
 import Link from "next/link";
 import ArticleCard from "@/components/ArticleCard";
 import Logo from "@/components/Logo";
+import { formatDistanceToNow } from "date-fns";
+import { faIR } from "date-fns/locale";
 
-const Index = () => {
-  // Sample articles data
-  const featuredArticles = [
-    {
-      id: "1",
-      title: "هوش مصنوعی و آینده‌ای که در انتظار ماست",
-      excerpt: "بررسی تأثیرات هوش مصنوعی بر جامعه، اقتصاد و زندگی روزمره انسان‌ها. چگونه این فناوری جهان را تغییر خواهد داد؟",
-      author: { name: "علی رضایی", avatar: "" },
-      readTime: 8,
-      publishDate: "۳ روز پیش",
-      claps: 124, // <-- تغییر از likes به claps
-      comments: 23,
-      category: "فناوری",
-      image: ""
+export const dynamic = "force-dynamic";
+
+const Index = async () => {
+  const [articleCount, authorCount, dailyReadersCount] = await Promise.all([
+    prisma.article.count({ where: { status: "APPROVED" } }),
+    prisma.user.count({
+      where: {
+        articles: { some: { status: "APPROVED" } },
+      },
+    }),
+    prisma.articleView.count({
+      where: {
+        viewedAt: {
+          gte: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        },
+      },
+    }),
+  ]);
+
+  const featuredArticles = await prisma.article.findMany({
+    where: { status: "APPROVED" },
+    orderBy: [
+      { claps: { _count: "desc" } },
+      { views: { _count: "desc" } },
+      { createdAt: "desc" },
+    ],
+    take: 3,
+    include: {
+      author: { select: { name: true, avatarUrl: true } },
+      categories: { select: { name: true } },
+      _count: { select: { claps: true, comments: true } },
     },
-    {
-      id: "2",
-      title: "سفری به دل تاریخ ایران باستان",
-      excerpt: "کاوش در اعماق تمدن ایرانی و بررسی دستاوردهای باستانیان که هنوز در زندگی امروز ما تأثیرگذار هستند.",
-      author: { name: "مریم احمدی", avatar: "" },
-      readTime: 12,
-      publishDate: "یک هفته پیش",
-      claps: 89, // <-- تغییر از likes به claps
-      comments: 15,
-      category: "تاریخ",
-      image: ""
-    },
-    {
-      id: "3",
-      title: "روان‌شناسی رنگ‌ها در معماری مدرن",
-      excerpt: "تأثیر رنگ‌ها بر روحیه انسان و چگونگی استفاده از این دانش در طراحی فضاهای زندگی و کار.",
-      author: { name: "محمد حسینی", avatar: "" },
-      readTime: 6,
-      publishDate: "۲ هفته پیش",
-      claps: 67, // <-- تغییر از likes به claps
-      comments: 8,
-      category: "هنر و معماری",
-      image: ""
-    }
-  ];
+  });
+
+  const formattedArticles = featuredArticles.map((article) => {
+    const plainContent = article.content.replace(/<[^>]*>?/gm, "");
+    const publishDate = formatDistanceToNow(new Date(article.createdAt), {
+      addSuffix: true,
+      locale: faIR,
+    });
+
+    return {
+      id: article.id.toString(),
+      title: article.title,
+      excerpt: plainContent.substring(0, 180) + (plainContent.length > 180 ? "..." : ""),
+      author: {
+        name: article.author.name || "ناشناس",
+        avatar: article.author.avatarUrl || undefined,
+      },
+      readTime: article.readTimeMinutes || Math.max(1, Math.round(plainContent.length / 900)),
+      publishDate,
+      claps: article._count.claps,
+      comments: article._count.comments,
+      category: article.categories[0]?.name || "عمومی",
+      image: article.coverImageUrl,
+    };
+  });
 
   return (
     <>
@@ -91,16 +111,22 @@ const Index = () => {
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
             <div className="text-center">
-              <div className="text-3xl font-bold text-journal-green mb-2">۱۲۰۰+</div>
+              <div className="text-3xl font-bold text-journal-green mb-2">
+                {articleCount.toLocaleString("fa-IR")}
+              </div>
               <p className="text-journal-light">مقاله منتشر شده</p>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold text-journal-green mb-2">۳۵۰+</div>
+              <div className="text-3xl font-bold text-journal-green mb-2">
+                {authorCount.toLocaleString("fa-IR")}
+              </div>
               <p className="text-journal-light">نویسنده فعال</p>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold text-journal-green mb-2">۸۵۰۰+</div>
-              <p className="text-journal-light">خواننده روزانه</p>
+              <div className="text-3xl font-bold text-journal-green mb-2">
+                {dailyReadersCount.toLocaleString("fa-IR")}
+              </div>
+              <p className="text-journal-light">بازدید ۲۴ ساعت گذشته</p>
             </div>
           </div>
         </div>
@@ -116,11 +142,17 @@ const Index = () => {
             </p>
           </div>
 
-          <div className="max-w-4xl mx-auto space-y-6">
-            {featuredArticles.map((article) => (
-              <ArticleCard key={article.id} {...article} />
-            ))}
-          </div>
+          {formattedArticles.length > 0 ? (
+            <div className="max-w-4xl mx-auto space-y-6">
+              {formattedArticles.map((article) => (
+                <ArticleCard key={article.id} {...article} />
+              ))}
+            </div>
+          ) : (
+            <div className="max-w-3xl mx-auto text-center py-16 text-journal-light">
+              هنوز مقاله تایید شده‌ای برای نمایش وجود ندارد. اولین نفری باشید که می‌نویسد!
+            </div>
+          )}
 
           <div className="text-center mt-12">
             <Link href="/articles">

--- a/src/app/publications/page.tsx
+++ b/src/app/publications/page.tsx
@@ -1,93 +1,112 @@
-// src/app/publications/page.tsx
-'use client';
+import { prisma } from "@/lib/prisma";
+import { PublicationCard } from "@/components/PublicationCard";
+import { Card, CardContent } from "@/components/ui/card";
+import { Users, FileText, Sparkles } from "lucide-react";
 
-import { useQuery } from '@tanstack/react-query';
-import { PublicationCard } from '@/components/PublicationCard';
-import { Skeleton } from '@/components/ui/skeleton';
+const PublicationsPage = async () => {
+  const publications = await prisma.publication.findMany({
+    include: {
+      _count: { select: { members: true, articles: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
 
-interface Publication {
-    id: number;
-    name: string;
-    slug: string;
-    description: string | null;
-    avatarUrl: string | null;
-    _count: {
-        members: number;
-        articles: number;
-    };
-}
+  const totalPublications = publications.length;
+  const totalMembers = publications.reduce((sum, publication) => sum + publication._count.members, 0);
+  const totalArticles = publications.reduce((sum, publication) => sum + publication._count.articles, 0);
 
-// تابع برای دریافت لیست انتشارات از API
-const fetchPublications = async (): Promise<Publication[]> => {
-    const response = await fetch('/api/publications');
-    if (!response.ok) {
-        throw new Error('Failed to fetch publications');
-    }
-    return response.json();
-};
+  const featuredPublications = [...publications]
+    .sort((a, b) => b._count.articles - a._count.articles)
+    .slice(0, 3);
 
-const PublicationsPage = () => {
-    const { data: publications, isLoading, isError } = useQuery<Publication[]>({
-        queryKey: ['publications'],
-        queryFn: fetchPublications,
-    });
-
-    return (
-        <div className="min-h-screen bg-background">
-            <section className="py-16 bg-muted/20">
-                <div className="container mx-auto px-4">
-                    <div className="max-w-4xl mx-auto text-center">
-                        <h1 className="text-4xl font-bold text-foreground mb-4">
-                            انتشارات روانیک
-                        </h1>
-                        <p className="text-xl text-muted-foreground">
-                            مجموعه‌ای از بهترین مجلات تخصصی فارسی را دنبال کنید.
-                        </p>
-                    </div>
-                </div>
-            </section>
-
-            <section className="py-12">
-                <div className="container mx-auto px-4">
-                    <div className="max-w-6xl mx-auto">
-                        {isLoading ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                {[...Array(4)].map((_, i) => (
-                                    <Skeleton key={i} className="h-48 w-full" />
-                                ))}
-                            </div>
-                        ) : isError ? (
-                            <div className="text-center py-12">
-                                <p className="text-destructive text-lg">
-                                    خطا در دریافت اطلاعات. لطفاً دوباره تلاش کنید.
-                                </p>
-                            </div>
-                        ) : publications && publications.length > 0 ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                {publications.map((pub) => (
-                                    <PublicationCard
-                                        key={pub.id}
-                                        name={pub.name}
-                                        slug={pub.slug}
-                                        description={pub.description}
-                                        avatarUrl={pub.avatarUrl}
-                                        membersCount={pub._count.members}
-                                        articlesCount={pub._count.articles}
-                                    />
-                                ))}
-                            </div>
-                        ) : (
-                            <div className="text-center py-12">
-                                <p className="text-muted-foreground text-lg">
-                                    هنوز هیچ انتشاراتی ثبت نشده است.
-                                </p>
-                            </div>
-                        )}
-                    </div>
-                </div>
-            </section>
+  return (
+    <div className="min-h-screen bg-background">
+      <section className="py-16 bg-muted/20">
+        <div className="container mx-auto px-4">
+          <div className="max-w-5xl mx-auto text-center space-y-6">
+            <h1 className="text-4xl font-bold text-foreground">انتشارات روانیک</h1>
+            <p className="text-lg text-muted-foreground">
+              از نشریات تخصصی و جمعی روانیک بازدید کنید و با نویسندگان حرفه‌ای همکاری داشته باشید.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <Card className="border-0 shadow-soft">
+                <CardContent className="flex flex-col items-center gap-2 py-6">
+                  <Users className="h-8 w-8 text-journal-green" />
+                  <p className="text-sm text-muted-foreground">کل اعضای فعال</p>
+                  <span className="text-2xl font-bold">{totalMembers.toLocaleString("fa-IR")}</span>
+                </CardContent>
+              </Card>
+              <Card className="border-0 shadow-soft">
+                <CardContent className="flex flex-col items-center gap-2 py-6">
+                  <FileText className="h-8 w-8 text-journal-orange" />
+                  <p className="text-sm text-muted-foreground">مجموع مقالات منتشر شده</p>
+                  <span className="text-2xl font-bold">{totalArticles.toLocaleString("fa-IR")}</span>
+                </CardContent>
+              </Card>
+              <Card className="border-0 shadow-soft">
+                <CardContent className="flex flex-col items-center gap-2 py-6">
+                  <Sparkles className="h-8 w-8 text-journal" />
+                  <p className="text-sm text-muted-foreground">تعداد نشریات فعال</p>
+                  <span className="text-2xl font-bold">{totalPublications.toLocaleString("fa-IR")}</span>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
         </div>
-    );
+      </section>
+
+      {featuredPublications.length > 0 && (
+        <section className="py-12">
+          <div className="container mx-auto px-4">
+            <div className="max-w-5xl mx-auto">
+              <h2 className="text-2xl font-bold text-foreground mb-6 text-center">نشریات پیشنهادی</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {featuredPublications.map((publication) => (
+                  <PublicationCard
+                    key={publication.id}
+                    name={publication.name}
+                    slug={publication.slug}
+                    description={publication.description}
+                    avatarUrl={publication.avatarUrl}
+                    membersCount={publication._count.members}
+                    articlesCount={publication._count.articles}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="py-12">
+        <div className="container mx-auto px-4">
+          <div className="max-w-6xl mx-auto">
+            {publications.length > 0 ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {publications.map((publication) => (
+                  <PublicationCard
+                    key={publication.id}
+                    name={publication.name}
+                    slug={publication.slug}
+                    description={publication.description}
+                    avatarUrl={publication.avatarUrl}
+                    membersCount={publication._count.members}
+                    articlesCount={publication._count.articles}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-12">
+                <p className="text-muted-foreground text-lg">
+                  هنوز هیچ انتشاراتی ثبت نشده است.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
 };
 
 export default PublicationsPage;

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,16 @@
+// src/app/support/page.tsx
+import type { Metadata } from "next";
+import { SupportCenter } from "@/components/SupportCenter";
+
+export const metadata: Metadata = {
+  title: "پشتیبانی روانیک",
+  description: "ارسال و پیگیری تیکت‌های پشتیبانی در مجله روانیک",
+};
+
+export default function SupportPage() {
+  return (
+    <div className="container mx-auto max-w-4xl px-4 py-12">
+      <SupportCenter />
+    </div>
+  );
+}

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -6,15 +6,17 @@ import { AdminUsersTab } from './AdminUsersTab';
 import { AdminArticlesTab } from './AdminArticlesTab';
 import { AdminCommentsTab } from './AdminCommentsTab';
 import { AdminSubscriptionsTab } from './AdminSubscriptionsTab'; // <-- ایمپورت جدید
+import { AdminSupportTab } from './AdminSupportTab';
 
 export const AdminDashboard = () => {
   return (
     <Tabs defaultValue="users" className="w-full">
-      <TabsList className="grid w-full grid-cols-4">
+      <TabsList className="grid w-full grid-cols-5">
         <TabsTrigger value="users">کاربران</TabsTrigger>
         <TabsTrigger value="articles">مقالات</TabsTrigger>
         <TabsTrigger value="comments">نظرات</TabsTrigger>
         <TabsTrigger value="subscriptions">اشتراک‌ها</TabsTrigger> {/* <-- تب جدید */}
+        <TabsTrigger value="support">تیکت‌ها</TabsTrigger>
       </TabsList>
       <TabsContent value="users">
         <AdminUsersTab />
@@ -27,6 +29,9 @@ export const AdminDashboard = () => {
       </TabsContent>
       <TabsContent value="subscriptions">
         <AdminSubscriptionsTab /> {/* <-- محتوای تب جدید */}
+      </TabsContent>
+      <TabsContent value="support">
+        <AdminSupportTab />
       </TabsContent>
     </Tabs>
   );

--- a/src/components/AdminSupportTab.tsx
+++ b/src/components/AdminSupportTab.tsx
@@ -1,0 +1,302 @@
+// src/components/AdminSupportTab.tsx
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+
+interface SupportAuthor {
+  id: number;
+  name: string | null;
+  role: string | null;
+  avatarUrl: string | null;
+}
+
+interface SupportMessage {
+  id: number;
+  body: string;
+  authorRole: "USER" | "ADMIN";
+  createdAt: string;
+  author: SupportAuthor | null;
+}
+
+interface SupportTicket {
+  id: number;
+  title: string;
+  status: "OPEN" | "ANSWERED" | "CLOSED";
+  statusLabel: string;
+  createdAt: string;
+  updatedAt: string;
+  user: {
+    id: number;
+    name: string | null;
+    email: string;
+    avatarUrl: string | null;
+  };
+  messages: SupportMessage[];
+}
+
+const statusOptions: { value: SupportTicket["status"]; label: string }[] = [
+  { value: "OPEN", label: "باز" },
+  { value: "ANSWERED", label: "پاسخ داده شده" },
+  { value: "CLOSED", label: "بسته شده" },
+];
+
+const statusStyles: Record<SupportTicket["status"], string> = {
+  OPEN: "bg-blue-100 text-blue-800",
+  ANSWERED: "bg-green-100 text-green-800",
+  CLOSED: "bg-gray-200 text-gray-800",
+};
+
+async function fetchAdminTickets(): Promise<SupportTicket[]> {
+  const response = await fetch("/api/admin/support/tickets");
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ message: "خطای ناشناخته" }));
+    throw new Error(payload?.message ?? "دریافت تیکت‌ها با خطا مواجه شد.");
+  }
+  return response.json();
+}
+
+interface ReplyInput {
+  ticketId: number;
+  message?: string;
+  status?: SupportTicket["status"];
+}
+
+async function replyToTicket(input: ReplyInput): Promise<SupportTicket> {
+  const response = await fetch(`/api/admin/support/tickets/${input.ticketId}/reply`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message: input.message, status: input.status }),
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ message: "خطای ناشناخته" }));
+    throw new Error(payload?.message ?? "ارسال پاسخ انجام نشد.");
+  }
+
+  return response.json();
+}
+
+export const AdminSupportTab = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
+  const [replyMessage, setReplyMessage] = useState("");
+  const [nextStatus, setNextStatus] = useState<SupportTicket["status"] | "">("");
+
+  const {
+    data: tickets,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["admin", "supportTickets"],
+    queryFn: fetchAdminTickets,
+  });
+
+  const replyMutation = useMutation({
+    mutationFn: replyToTicket,
+    onSuccess: () => {
+      toast({
+        title: "پاسخ ثبت شد",
+        description: "پیام شما برای کاربر ارسال شد.",
+      });
+      setReplyMessage("");
+      setNextStatus("");
+      queryClient.invalidateQueries({ queryKey: ["admin", "supportTickets"] });
+    },
+    onError: (err: unknown) => {
+      const description = err instanceof Error ? err.message : "لطفاً دوباره تلاش کنید.";
+      toast({
+        variant: "destructive",
+        title: "خطا در ثبت پاسخ",
+        description,
+      });
+    },
+  });
+
+  const orderedTickets = useMemo(() => {
+    if (!tickets) return [];
+    return [...tickets].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }, [tickets]);
+
+  useEffect(() => {
+    if (!selectedTicketId && orderedTickets.length > 0) {
+      setSelectedTicketId(orderedTickets[0].id);
+    }
+  }, [orderedTickets, selectedTicketId]);
+
+  const selectedTicket = useMemo(() => {
+    if (!selectedTicketId) return null;
+    return orderedTickets.find((ticket) => ticket.id === selectedTicketId) ?? null;
+  }, [orderedTickets, selectedTicketId]);
+
+  const handleReply = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedTicket) {
+      toast({ variant: "destructive", title: "ابتدا یک تیکت را انتخاب کنید." });
+      return;
+    }
+
+    if (!replyMessage.trim() && !nextStatus) {
+      toast({
+        variant: "destructive",
+        title: "اطلاعات ناقص",
+        description: "لطفاً متن پاسخ یا وضعیت جدید را مشخص کنید.",
+      });
+      return;
+    }
+
+    replyMutation.mutate({
+      ticketId: selectedTicket.id,
+      message: replyMessage.trim() || undefined,
+      status: nextStatus || undefined,
+    });
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[280px_1fr]">
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle>لیست تیکت‌ها</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="space-y-3 p-4">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : isError ? (
+            <div className="p-6 text-sm text-destructive">
+              {error instanceof Error ? error.message : "خطا در دریافت تیکت‌ها."}
+            </div>
+          ) : orderedTickets.length === 0 ? (
+            <div className="p-6 text-sm text-muted-foreground">هنوز تیکتی ثبت نشده است.</div>
+          ) : (
+            <ScrollArea className="h-[480px]">
+              <div className="divide-y">
+                {orderedTickets.map((ticket) => (
+                  <button
+                    key={ticket.id}
+                    onClick={() => setSelectedTicketId(ticket.id)}
+                    className={`flex w-full flex-col items-start gap-2 px-4 py-3 text-right transition ${
+                      selectedTicketId === ticket.id ? "bg-muted" : "hover:bg-muted/60"
+                    }`}
+                  >
+                    <div className="flex w-full items-center justify-between">
+                      <span className="text-sm font-semibold text-journal">{ticket.title}</span>
+                      <Badge className={statusStyles[ticket.status]}>{ticket.statusLabel}</Badge>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      {ticket.user.name || ticket.user.email}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle>جزئیات تیکت</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {!selectedTicket ? (
+            <div className="text-sm text-muted-foreground">
+              یکی از تیکت‌های سمت راست را انتخاب کنید تا مکاتبات نمایش داده شود.
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-lg font-semibold text-journal">{selectedTicket.title}</p>
+                    <p className="text-sm text-muted-foreground">
+                      توسط {selectedTicket.user.name || selectedTicket.user.email}
+                    </p>
+                  </div>
+                  <Badge className={statusStyles[selectedTicket.status]}>{selectedTicket.statusLabel}</Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  تاریخ ثبت: {new Intl.DateTimeFormat("fa-IR", { dateStyle: "full", timeStyle: "short" }).format(new Date(selectedTicket.createdAt))}
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold text-journal">مکالمه</h3>
+                <div className="space-y-3">
+                  {selectedTicket.messages.map((message) => (
+                    <div
+                      key={message.id}
+                      className={`rounded-lg border border-border p-4 ${
+                        message.authorRole === "ADMIN" ? "bg-muted" : "bg-background"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-semibold text-journal">
+                          {message.authorRole === "ADMIN" ? "پشتیبانی" : message.author?.name || "کاربر"}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {new Intl.DateTimeFormat("fa-IR", {
+                            dateStyle: "short",
+                            timeStyle: "short",
+                          }).format(new Date(message.createdAt))}
+                        </span>
+                      </div>
+                      <p className="mt-3 text-sm leading-7 text-journal-light">{message.body}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <form className="space-y-4" onSubmit={handleReply}>
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-journal">پاسخ پشتیبانی</label>
+                  <Textarea
+                    rows={4}
+                    value={replyMessage}
+                    onChange={(event) => setReplyMessage(event.target.value)}
+                    placeholder="پاسخ خود را برای کاربر بنویسید..."
+                  />
+                </div>
+                <div className="flex flex-wrap items-center gap-3 text-sm">
+                  <span className="text-journal">وضعیت تیکت:</span>
+                  <div className="flex flex-wrap gap-2">
+                    {statusOptions.map((option) => (
+                      <Button
+                        type="button"
+                        key={option.value}
+                        variant={nextStatus === option.value ? "default" : "outline"}
+                        size="sm"
+                        onClick={() =>
+                          setNextStatus((current) => (current === option.value ? "" : option.value))
+                        }
+                      >
+                        {option.label}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex justify-end">
+                  <Button type="submit" disabled={replyMutation.isPending}>
+                    {replyMutation.isPending ? "در حال ارسال..." : "ارسال پاسخ"}
+                  </Button>
+                </div>
+              </form>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,6 +41,9 @@ const Header = () => {
             <Link href="/categories" className="text-journal-light hover:text-journal transition-colors">
               دسته‌بندی‌ها
             </Link>
+            <Link href="/support" className="text-journal-light hover:text-journal transition-colors">
+              پشتیبانی
+            </Link>
             <Link href="/about" className="text-journal-light hover:text-journal transition-colors">
               درباره ما
             </Link>
@@ -89,6 +92,9 @@ const Header = () => {
                     </Link>
                     <Link href="/categories" onClick={handleLinkClick} className="text-lg text-journal-light hover:text-journal transition-colors">
                       دسته‌بندی‌ها
+                    </Link>
+                    <Link href="/support" onClick={handleLinkClick} className="text-lg text-journal-light hover:text-journal transition-colors">
+                      پشتیبانی
                     </Link>
                     <Link href="/about" onClick={handleLinkClick} className="text-lg text-journal-light hover:text-journal transition-colors">
                       درباره ما

--- a/src/components/ProfileClient.tsx
+++ b/src/components/ProfileClient.tsx
@@ -1,22 +1,30 @@
 // src/components/ProfileClient.tsx
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
-import { Edit3, LogOut, Crown, Loader2, Pin, PinOff, History } from "lucide-react";
+import { Edit3, LogOut, Crown, Loader2, Pin, PinOff, History, Download } from "lucide-react";
 import ArticleCard from "@/components/ArticleCard";
 import { useRouter } from "next/navigation";
 import { ProfileSettings } from "./ProfileSettings";
 import { DeleteArticleButton } from "./DeleteArticleButton";
 import { Skeleton } from "./ui/skeleton";
 import { AnalyticsDashboard } from "./AnalyticsDashboard";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, QueryFunctionContext } from "@tanstack/react-query";
 import { Prisma } from "@prisma/client";
 import { useToast } from "@/components/ui/use-toast";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 // =======================================================================
 //  1. تعریف تایپ‌ها (Types)
@@ -30,6 +38,27 @@ type FetchedArticle = Prisma.ArticleGetPayload<{
     categories: { select: { name: true } };
   }
 }>;
+
+type ReadingHistoryItem = {
+  viewedAt: string;
+  article: FetchedArticle;
+};
+
+type HistoryFilters = {
+  search?: string;
+  range: string;
+  categoryId?: number | null;
+};
+
+type HistoryQueryKey = readonly ["readingHistory", HistoryFilters];
+
+const HISTORY_RANGE_LABELS: Record<string, string> = {
+  "7d": "۷ روز اخیر",
+  "30d": "۳۰ روز اخیر",
+  "90d": "۹۰ روز اخیر",
+  "365d": "۱ سال اخیر",
+  all: "همه زمان‌ها",
+};
 
 // تایپ اصلی برای داده‌های کاربر که از صفحه سرور می‌آید
 type UserPayload = Prisma.UserGetPayload<{
@@ -87,8 +116,28 @@ const pinArticleRequest = async (articleId: number | null) => {
   return response.json();
 };
 
-const fetchReadingHistory = async (): Promise<FetchedArticle[]> => {
-  const response = await fetch("/api/me/reading-history");
+const fetchReadingHistory = async (
+  { queryKey }: QueryFunctionContext<HistoryQueryKey>
+): Promise<ReadingHistoryItem[]> => {
+  const [, params] = queryKey;
+  const urlParams = new URLSearchParams();
+
+  if (params.search) {
+    urlParams.set("q", params.search);
+  }
+
+  if (params.range) {
+    urlParams.set("range", params.range);
+  }
+
+  if (params.categoryId) {
+    urlParams.set("categoryId", params.categoryId.toString());
+  }
+
+  const queryString = urlParams.toString();
+  const response = await fetch(
+    `/api/me/reading-history${queryString ? `?${queryString}` : ""}`
+  );
   if (!response.ok) throw new Error("Failed to fetch reading history");
   return response.json();
 };
@@ -154,6 +203,50 @@ export const ProfileClient = ({ user }: ProfileClientProps) => {
   const queryClient = useQueryClient();
 
   const [pinnedArticleId, setPinnedArticleId] = useState(user.pinnedArticleId);
+  const [historyRange, setHistoryRange] = useState("30d");
+  const [historySearch, setHistorySearch] = useState("");
+  const [debouncedHistorySearch, setDebouncedHistorySearch] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedHistorySearch(historySearch.trim());
+    }, 400);
+
+    return () => clearTimeout(timer);
+  }, [historySearch]);
+
+  const historyFilters = useMemo<HistoryFilters>(
+    () => ({
+      search: debouncedHistorySearch || undefined,
+      range: historyRange,
+    }),
+    [debouncedHistorySearch, historyRange]
+  );
+
+  const historyQueryKey = useMemo<HistoryQueryKey>(
+    () => ["readingHistory", historyFilters],
+    [historyFilters]
+  );
+
+  const currentRangeLabel = HISTORY_RANGE_LABELS[historyRange] ?? HISTORY_RANGE_LABELS["30d"];
+
+  const handleExportHistory = () => {
+    const params = new URLSearchParams();
+    if (debouncedHistorySearch) {
+      params.set("q", debouncedHistorySearch);
+    }
+    if (historyRange) {
+      params.set("range", historyRange);
+    }
+
+    const queryString = params.toString();
+    if (typeof window !== "undefined") {
+      window.open(
+        `/api/me/reading-history/export${queryString ? `?${queryString}` : ""}`,
+        "_blank"
+      );
+    }
+  };
 
   const { data: savedArticles, isLoading: isLoadingSaved, isError: isErrorSaved } = useQuery<FetchedArticle[]>({
     queryKey: ['savedArticles'],
@@ -167,10 +260,14 @@ export const ProfileClient = ({ user }: ProfileClientProps) => {
     enabled: activeTab === 'clapped',
   });
 
-  const { data: historyArticles, isLoading: isLoadingHistory, isError: isErrorHistory } = useQuery<FetchedArticle[]>({
-    queryKey: ['readingHistory'],
+  const {
+    data: historyArticles,
+    isLoading: isLoadingHistory,
+    isError: isErrorHistory,
+  } = useQuery<ReadingHistoryItem[], Error, ReadingHistoryItem[], HistoryQueryKey>({
+    queryKey: historyQueryKey,
     queryFn: fetchReadingHistory,
-    enabled: activeTab === 'history',
+    enabled: activeTab === "history",
   });
 
   const pinMutation = useMutation({
@@ -319,32 +416,89 @@ export const ProfileClient = ({ user }: ProfileClientProps) => {
                 <Card className="shadow-soft border-0">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2"><History className="h-5 w-5" />تاریخچه مطالعه</CardTitle>
-                    <CardDescription>آخرین مقالاتی که مطالعه کرده‌اید.</CardDescription>
+                    <CardDescription>
+                      آخرین مقالاتی که مطالعه کرده‌اید. نتایج را بر اساس بازه زمانی یا جست‌وجوی متن محدود کنید.
+                    </CardDescription>
                   </CardHeader>
                   <CardContent>
+                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+                      <Input
+                        value={historySearch}
+                        onChange={(event) => setHistorySearch(event.target.value)}
+                        placeholder="جست‌وجو بر اساس عنوان یا محتوای مقاله"
+                        className="md:max-w-sm"
+                      />
+                      <div className="flex items-center gap-2">
+                        <Select value={historyRange} onValueChange={setHistoryRange}>
+                          <SelectTrigger className="w-32">
+                            <SelectValue placeholder="بازه" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="7d">۷ روز اخیر</SelectItem>
+                            <SelectItem value="30d">۳۰ روز اخیر</SelectItem>
+                            <SelectItem value="90d">۹۰ روز اخیر</SelectItem>
+                            <SelectItem value="365d">۱ سال اخیر</SelectItem>
+                            <SelectItem value="all">همه زمان‌ها</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <Button
+                          variant="outline"
+                          onClick={handleExportHistory}
+                          disabled={isLoadingHistory || (historyArticles?.length ?? 0) === 0}
+                        >
+                          <Download className="ml-2 h-4 w-4" />
+                          خروجی CSV
+                        </Button>
+                      </div>
+                    </div>
                     {isLoadingHistory ? (
                       <div className="space-y-4"><Skeleton className="h-24 w-full" /><Skeleton className="h-24 w-full" /></div>
                     ) : isErrorHistory ? (
                       <p className="text-red-500 text-center">خطا در دریافت تاریخچه مطالعه.</p>
                     ) : historyArticles && historyArticles.length > 0 ? (
                       <div className="space-y-6">
-                        {historyArticles.map((article) => (
-                          <ArticleCard
-                            key={article.id}
-                            id={article.id.toString()}
-                            title={article.title}
-                            excerpt={article.content.substring(0, 150) + "..."}
-                            image={article.coverImageUrl}
-                            author={{ name: article.author.name || "ناشناس", avatar: article.author.avatarUrl }}
-                            readTime={article.readTimeMinutes || 1}
-                            publishDate={new Intl.DateTimeFormat("fa-IR").format(new Date(article.createdAt))}
-                            claps={article._count.claps}
-                            comments={article._count.comments}
-                            category={article.categories[0]?.name || "عمومی"}
-                          />
-                        ))}
+                        {historyArticles.map(({ article, viewedAt }) => {
+                          const plainContent = article.content.replace(/<[^>]*>?/gm, "");
+                          const preview = plainContent.substring(0, 150);
+                          const excerpt = preview + (plainContent.length > 150 ? "..." : "");
+
+                          return (
+                            <div key={`${article.id}-${viewedAt}`} className="space-y-2">
+                              <ArticleCard
+                                id={article.id.toString()}
+                                title={article.title}
+                                excerpt={excerpt}
+                                image={article.coverImageUrl}
+                                author={{
+                                  name: article.author.name || "ناشناس",
+                                  avatar: article.author.avatarUrl,
+                                }}
+                                readTime={article.readTimeMinutes || 1}
+                                publishDate={new Intl.DateTimeFormat("fa-IR").format(
+                                  new Date(article.createdAt)
+                                )}
+                                claps={article._count.claps}
+                                comments={article._count.comments}
+                                category={article.categories[0]?.name || "عمومی"}
+                              />
+                              <div className="flex justify-between text-xs text-muted-foreground px-2">
+                                <span>
+                                  آخرین مطالعه: {new Intl.DateTimeFormat("fa-IR", {
+                                    dateStyle: "medium",
+                                    timeStyle: "short",
+                                  }).format(new Date(viewedAt))}
+                                </span>
+                                <span>بازه فعال: {currentRangeLabel}</span>
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
-                    ) : (<p className="text-center text-muted-foreground py-8">تاریخچه مطالعه شما خالی است.</p>)}
+                    ) : (
+                      <p className="text-center text-muted-foreground py-8">
+                        تاریخچه مطالعه شما خالی است.
+                      </p>
+                    )}
                   </CardContent>
                 </Card>
               </TabsContent>

--- a/src/components/SupportCenter.tsx
+++ b/src/components/SupportCenter.tsx
@@ -1,0 +1,246 @@
+// src/components/SupportCenter.tsx
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+
+interface SupportAuthor {
+  id: number;
+  name: string | null;
+  role: string | null;
+  avatarUrl: string | null;
+}
+
+interface SupportMessage {
+  id: number;
+  body: string;
+  authorRole: "USER" | "ADMIN";
+  createdAt: string;
+  author: SupportAuthor | null;
+}
+
+interface SupportTicket {
+  id: number;
+  title: string;
+  status: "OPEN" | "ANSWERED" | "CLOSED";
+  statusLabel: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: SupportMessage[];
+}
+
+const statusStyles: Record<SupportTicket["status"], string> = {
+  OPEN: "bg-blue-100 text-blue-800",
+  ANSWERED: "bg-green-100 text-green-800",
+  CLOSED: "bg-gray-200 text-gray-800",
+};
+
+const statusDescriptions: Record<SupportTicket["status"], string> = {
+  OPEN: "در انتظار بررسی تیم پشتیبانی",
+  ANSWERED: "پاسخ از سوی تیم پشتیبانی ثبت شده است",
+  CLOSED: "این تیکت بسته شده است",
+};
+
+async function fetchTickets(): Promise<SupportTicket[]> {
+  const response = await fetch("/api/support/tickets");
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ message: "خطای ناشناخته" }));
+    throw new Error(payload?.message ?? "خطا در دریافت تیکت‌ها");
+  }
+  return response.json();
+}
+
+interface CreateTicketInput {
+  title: string;
+  message: string;
+}
+
+async function createTicket(input: CreateTicketInput): Promise<SupportTicket> {
+  const response = await fetch("/api/support/tickets", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ message: "خطای ناشناخته" }));
+    throw new Error(payload?.message ?? "ثبت تیکت با خطا مواجه شد");
+  }
+
+  return response.json();
+}
+
+export const SupportCenter = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+
+  const { data: tickets, isLoading, isError, error } = useQuery({
+    queryKey: ["supportTickets"],
+    queryFn: fetchTickets,
+  });
+
+  const createTicketMutation = useMutation({
+    mutationFn: createTicket,
+    onSuccess: () => {
+      toast({
+        title: "تیکت شما ثبت شد",
+        description: "همکاران ما در سریع‌ترین زمان ممکن پاسخ خواهند داد.",
+      });
+      setTitle("");
+      setMessage("");
+      queryClient.invalidateQueries({ queryKey: ["supportTickets"] });
+    },
+    onError: (err: unknown) => {
+      const description = err instanceof Error ? err.message : "لطفاً دوباره تلاش کنید.";
+      toast({
+        variant: "destructive",
+        title: "خطا در ثبت تیکت",
+        description,
+      });
+    },
+  });
+
+  const sortedTickets = useMemo(() => {
+    if (!tickets) return [];
+    return [...tickets].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }, [tickets]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!title.trim() || !message.trim()) {
+      toast({
+        variant: "destructive",
+        title: "اطلاعات ناقص",
+        description: "لطفاً عنوان و متن پیام را کامل کنید.",
+      });
+      return;
+    }
+    createTicketMutation.mutate({ title: title.trim(), message: message.trim() });
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-3 text-center">
+        <h1 className="text-3xl font-bold text-journal">پشتیبانی روانیک</h1>
+        <p className="text-muted-foreground">
+          اگر سوال، مشکل یا پیشنهادی دارید، از این بخش برای ارتباط مستقیم با تیم پشتیبانی استفاده کنید.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>ارسال درخواست جدید</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div>
+              <label className="mb-2 block text-sm font-medium text-journal">عنوان تیکت</label>
+              <Input
+                placeholder="مثلاً مشکل در انتشار مقاله"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+              />
+            </div>
+            <div>
+              <label className="mb-2 block text-sm font-medium text-journal">متن پیام</label>
+              <Textarea
+                rows={5}
+                placeholder="توضیح دهید چه مشکلی دارید یا چه انتظاری از تیم پشتیبانی دارید."
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+              />
+            </div>
+            <div className="flex justify-end">
+              <Button type="submit" disabled={createTicketMutation.isPending}>
+                {createTicketMutation.isPending ? "در حال ارسال..." : "ثبت تیکت"}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-semibold text-journal">تیکت‌های شما</h2>
+          <span className="text-sm text-muted-foreground">
+            همه مکاتبات شما با تیم پشتیبانی در اینجا نمایش داده می‌شود.
+          </span>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+          </div>
+        ) : isError ? (
+          <Card>
+            <CardContent className="py-10 text-center text-destructive">
+              {error instanceof Error ? error.message : "دریافت تیکت‌ها با خطا مواجه شد."}
+            </CardContent>
+          </Card>
+        ) : sortedTickets.length === 0 ? (
+          <Card>
+            <CardContent className="py-10 text-center text-muted-foreground">
+              هنوز تیکتی ثبت نکرده‌اید.
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {sortedTickets.map((ticket) => (
+              <Card key={ticket.id}>
+                <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <CardTitle className="text-lg">{ticket.title}</CardTitle>
+                    <p className="text-sm text-muted-foreground">
+                      {new Intl.DateTimeFormat("fa-IR", {
+                        dateStyle: "full",
+                        timeStyle: "short",
+                      }).format(new Date(ticket.createdAt))}
+                    </p>
+                  </div>
+                  <div className="flex flex-col items-start gap-2 md:items-end">
+                    <Badge className={statusStyles[ticket.status]}>{ticket.statusLabel}</Badge>
+                    <span className="text-xs text-muted-foreground">{statusDescriptions[ticket.status]}</span>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {ticket.messages.map((messageItem) => (
+                    <div
+                      key={messageItem.id}
+                      className={`rounded-lg border border-border p-4 ${
+                        messageItem.authorRole === "ADMIN" ? "bg-muted" : "bg-background"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-semibold text-journal">
+                          {messageItem.authorRole === "ADMIN" ? "پاسخ پشتیبانی" : "پیام شما"}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {new Intl.DateTimeFormat("fa-IR", {
+                            dateStyle: "short",
+                            timeStyle: "short",
+                          }).format(new Date(messageItem.createdAt))}
+                        </span>
+                      </div>
+                      <p className="mt-3 text-sm leading-7 text-journal-light">{messageItem.body}</p>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,17 @@
+import { prisma } from "@/lib/prisma";
+
+export async function getNotificationsSnapshot(userId: number) {
+  const [notifications, unreadCount] = await Promise.all([
+    prisma.notification.findMany({
+      where: { userId },
+      include: {
+        actor: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    }),
+    prisma.notification.count({ where: { userId, isRead: false } }),
+  ]);
+
+  return { notifications, unreadCount };
+}

--- a/src/lib/reading-history.ts
+++ b/src/lib/reading-history.ts
@@ -1,0 +1,104 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+type RangeOption = "7d" | "30d" | "90d" | "365d" | "all";
+
+export interface ReadingHistoryFilters {
+  search?: string;
+  range?: RangeOption;
+  categoryId?: number;
+  limit?: number;
+}
+
+export interface ReadingHistoryEntry {
+  viewedAt: Date;
+  article: Prisma.ArticleGetPayload<{
+    include: {
+      author: { select: { name: true; avatarUrl: true } };
+      categories: { select: { name: true } };
+      _count: { select: { claps: true; comments: true } };
+    };
+  }>;
+}
+
+const resolveRange = (range?: RangeOption) => {
+  switch (range) {
+    case "7d":
+      return 7;
+    case "30d":
+      return 30;
+    case "90d":
+      return 90;
+    case "365d":
+      return 365;
+    default:
+      return undefined;
+  }
+};
+
+export async function getReadingHistoryEntries(
+  userId: number,
+  { search, range = "30d", categoryId, limit = 50 }: ReadingHistoryFilters = {}
+): Promise<ReadingHistoryEntry[]> {
+  const normalizedLimit = Math.min(Math.max(limit, 1), 200);
+  const days = resolveRange(range);
+
+  const where: Prisma.ReadingHistoryWhereInput = {
+    userId,
+  };
+
+  if (days) {
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+    where.viewedAt = { gte: since };
+  }
+
+  const articleFilters: Prisma.ArticleWhereInput = {};
+
+  if (search) {
+    const normalizedSearch = search.trim();
+    if (normalizedSearch.length > 0) {
+      articleFilters.OR = [
+        { title: { contains: normalizedSearch, mode: "insensitive" } },
+        { content: { contains: normalizedSearch, mode: "insensitive" } },
+        {
+          categories: {
+            some: { name: { contains: normalizedSearch, mode: "insensitive" } },
+          },
+        },
+      ];
+    }
+  }
+
+  if (categoryId) {
+    articleFilters.categories = {
+      some: { id: categoryId },
+    };
+  }
+
+  if (Object.keys(articleFilters).length > 0) {
+    where.article = {
+      ...articleFilters,
+    };
+  }
+
+  const history = await prisma.readingHistory.findMany({
+    where,
+    orderBy: { viewedAt: "desc" },
+    take: normalizedLimit,
+    include: {
+      article: {
+        include: {
+          author: { select: { name: true, avatarUrl: true } },
+          categories: { select: { name: true } },
+          _count: { select: { claps: true, comments: true } },
+        },
+      },
+    },
+  });
+
+  return history.map((entry) => ({
+    viewedAt: entry.viewedAt,
+    article: entry.article,
+  }));
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,8 +6,10 @@ export const config = {
   matcher: [
     '/profile/:path*',
     '/write/:path*',
+    '/support/:path*',
     '/admin/:path*',
-    '/api/admin/:path*'
+    '/api/admin/:path*',
+    '/api/support/:path*'
   ],
 };
 


### PR DESCRIPTION
## Summary
- add Prisma models and API endpoints to persist support tickets and admin replies
- build a user-facing support center page and surface the link in the global navigation with auth protection
- extend the admin dashboard with a dedicated ticket management tab that lets staff reply and update statuses

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e12e9482a08332b1c5991f624d8ec7