### PR TITLE
Harden support ticket API constraints

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,43 @@
 // next.config.js
+const runtimeCaching = [
+    {
+        urlPattern: /^https?:\/\/res\.cloudinary\.com\/.*$/,
+        handler: "CacheFirst",
+        options: {
+            cacheName: "revanic-images",
+            expiration: { maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 * 30 },
+            cacheableResponse: { statuses: [0, 200] },
+        },
+    },
+    {
+        urlPattern: /^https?:\/\/fonts\.gstatic\.com\/.*$/,
+        handler: "CacheFirst",
+        options: {
+            cacheName: "revanic-fonts",
+            expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 365 },
+        },
+    },
+    {
+        urlPattern: ({ request }) => request.destination === "document" || request.destination === "script",
+        handler: "NetworkFirst",
+        options: {
+            cacheName: "revanic-pages",
+            networkTimeoutSeconds: 10,
+            expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 },
+        },
+    },
+    // مسیرهای API خصوصی به‌صورت عمدی کش نمی‌شوند تا داده‌های کاربر در Cache Storage باقی نماند.
+];
+
 const withPWA = require("next-pwa")({
     dest: "public",
     register: true,
     skipWaiting: true,
-    disable: process.env.NODE_ENV === "development", // PWA را در حالت توسعه غیرفعال می‌کند
+    disable: process.env.NODE_ENV === "development",
+    runtimeCaching,
+    fallbacks: {
+        document: "/offline",
+    },
 });
 
 /** @type {import('next').NextConfig} */

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,9 +34,11 @@ model User {
   updatedAt              DateTime       @updatedAt
   publications           UsersOnPublications[]
   highlights             Highlight[]
-  
+
   // --- فیلد جدید برای تاریخچه مطالعه ---
   readingHistory         ReadingHistory[]
+  supportTickets         SupportTicket[]
+  supportMessages        SupportMessage[] @relation("SupportMessageAuthor")
 }
 
 model Article {
@@ -66,6 +68,58 @@ model Article {
 
   // --- فیلد جدید برای تاریخچه مطالعه ---
   history       ReadingHistory[]
+}
+
+model SupportTicket {
+  id        Int                   @id @default(autoincrement())
+  title     String
+  status    SupportTicketStatus   @default(OPEN)
+  priority  SupportTicketPriority @default(NORMAL)
+  user      User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    Int
+  messages  SupportMessage[]
+  createdAt DateTime              @default(now())
+  updatedAt DateTime              @updatedAt
+}
+
+model SupportMessage {
+  id          Int                      @id @default(autoincrement())
+  body        String
+  authorRole  SupportMessageAuthorRole
+  ticket      SupportTicket            @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  ticketId    Int
+  author      User?                    @relation("SupportMessageAuthor", fields: [authorId], references: [id], onDelete: SetNull)
+  authorId    Int?
+  attachments SupportAttachment[]
+  createdAt   DateTime                 @default(now())
+}
+
+model SupportAttachment {
+  id        Int            @id @default(autoincrement())
+  url       String
+  mimeType  String
+  size      Int
+  filename  String?
+  message   SupportMessage @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  messageId Int
+  createdAt DateTime       @default(now())
+}
+
+enum SupportTicketStatus {
+  OPEN
+  ANSWERED
+  CLOSED
+}
+
+enum SupportTicketPriority {
+  LOW
+  NORMAL
+  HIGH
+}
+
+enum SupportMessageAuthorRole {
+  USER
+  ADMIN
 }
 
 model Publication {

--- a/src/app/api/admin/stats/stream/route.ts
+++ b/src/app/api/admin/stats/stream/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { getAdminDashboardStats } from "@/lib/admin/statsService";
+import { requireAdminSession } from "@/lib/admin-auth";
+
+const encoder = new TextEncoder();
+
+const sendEvent = (controller: ReadableStreamDefaultController, data: unknown) => {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+};
+
+const sendHeartbeat = (controller: ReadableStreamDefaultController) => {
+  controller.enqueue(encoder.encode(`: keep-alive\n\n`));
+};
+
+export async function GET(request: Request) {
+  try {
+    const adminSession = await requireAdminSession();
+
+    if (!adminSession) {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
+
+    let active = true;
+    let interval: NodeJS.Timeout | undefined;
+    let heartbeat: NodeJS.Timeout | undefined;
+    let lastPayload = "";
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        const pushStats = async (force = false) => {
+          const stats = await getAdminDashboardStats();
+          const serialized = JSON.stringify(stats);
+          if (force || serialized !== lastPayload) {
+            lastPayload = serialized;
+            sendEvent(controller, stats);
+          }
+        };
+
+        await pushStats(true);
+
+        interval = setInterval(() => {
+          if (!active) return;
+          pushStats();
+        }, 10000);
+
+        heartbeat = setInterval(() => {
+          if (!active) return;
+          sendHeartbeat(controller);
+        }, 15000);
+
+        const abort = () => {
+          active = false;
+          if (interval) {
+            clearInterval(interval);
+          }
+          if (heartbeat) {
+            clearInterval(heartbeat);
+          }
+          controller.close();
+        };
+
+        request.signal.addEventListener("abort", abort);
+      },
+      cancel() {
+        active = false;
+        if (interval) {
+          clearInterval(interval);
+        }
+        if (heartbeat) {
+          clearInterval(heartbeat);
+        }
+      },
+    });
+
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    console.error("ADMIN_STATS_STREAM_ERROR", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/api/admin/support/tickets/[id]/reply/route.ts
+++ b/src/app/api/admin/support/tickets/[id]/reply/route.ts
@@ -1,0 +1,141 @@
+// src/app/api/admin/support/tickets/[id]/reply/route.ts
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import type { Prisma, SupportTicketStatus } from "@prisma/client";
+import { requireAdminSession } from "@/lib/admin-auth";
+import {
+  SUPPORT_STATUS_TEXTS,
+  SUPPORT_PRIORITY_TEXTS,
+  type SupportTicketPriorityKey,
+} from "@/lib/support";
+
+const statusTexts = SUPPORT_STATUS_TEXTS;
+const priorityTexts = SUPPORT_PRIORITY_TEXTS;
+
+const allowedStatuses: SupportTicketStatus[] = ["OPEN", "ANSWERED", "CLOSED"];
+type SupportTicketPriority = SupportTicketPriorityKey;
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const adminSession = await requireAdminSession();
+  if (!adminSession) {
+    return NextResponse.json({ message: "دسترسی غیرمجاز." }, { status: 403 });
+  }
+
+  const ticketId = Number(params.id);
+  if (!ticketId || Number.isNaN(ticketId)) {
+    return NextResponse.json({ message: "شناسه تیکت نامعتبر است." }, { status: 400 });
+  }
+
+  try {
+    const body = await request.json();
+    const message: string | undefined = body?.message?.trim();
+    const status = body?.status as SupportTicketStatus | undefined;
+    const priority = body?.priority as SupportTicketPriority | undefined;
+
+    if (!message && !status && !priority) {
+      return NextResponse.json(
+        { message: "لطفاً متن پاسخ، وضعیت جدید یا اولویت تازه را ارسال کنید." },
+        { status: 400 }
+      );
+    }
+
+    if (status && !allowedStatuses.includes(status)) {
+      return NextResponse.json(
+        { message: "وضعیت انتخاب شده معتبر نیست." },
+        { status: 400 }
+      );
+    }
+
+    if (priority && !priorityTexts[priority]) {
+      return NextResponse.json(
+        { message: "اولویت انتخاب‌شده معتبر نیست." },
+        { status: 400 }
+      );
+    }
+
+    const ticketExists = await prisma.supportTicket.findUnique({
+      where: { id: ticketId },
+      select: { id: true },
+    });
+
+    if (!ticketExists) {
+      return NextResponse.json(
+        { message: "تیکت مورد نظر یافت نشد." },
+        { status: 404 }
+      );
+    }
+
+    await prisma.$transaction(async (tx) => {
+      if (message) {
+        await tx.supportMessage.create({
+          data: {
+            ticketId,
+            body: message,
+            authorRole: "ADMIN",
+            authorId: adminSession.id,
+          },
+        });
+      }
+
+      const updateData: Prisma.SupportTicketUpdateInput = {
+        updatedAt: new Date(),
+      };
+
+      if (status) {
+        updateData.status = status;
+      }
+
+      if (priority) {
+        updateData.priority = priority;
+      }
+
+      await tx.supportTicket.update({
+        where: { id: ticketId },
+        data: updateData,
+      });
+    });
+
+    const refreshedTicket = await prisma.supportTicket.findUnique({
+      where: { id: ticketId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            avatarUrl: true,
+          },
+        },
+        messages: {
+          orderBy: { createdAt: "asc" },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                role: true,
+                avatarUrl: true,
+              },
+            },
+            attachments: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({
+      ...refreshedTicket,
+      statusLabel: refreshedTicket ? statusTexts[refreshedTicket.status] : undefined,
+      priorityLabel: refreshedTicket ? priorityTexts[refreshedTicket.priority] : undefined,
+    });
+  } catch (error) {
+    console.error("ADMIN_SUPPORT_REPLY_ERROR", error);
+    return NextResponse.json(
+      { message: "ارسال پاسخ با خطا مواجه شد." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/support/tickets/route.ts
+++ b/src/app/api/admin/support/tickets/route.ts
@@ -1,0 +1,98 @@
+// src/app/api/admin/support/tickets/route.ts
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdminSession } from "@/lib/admin-auth";
+import {
+  SUPPORT_STATUS_TEXTS,
+  SUPPORT_PRIORITY_TEXTS,
+  type SupportTicketPriorityKey,
+  type SupportTicketStatusKey,
+} from "@/lib/support";
+import type { Prisma } from "@prisma/client";
+
+const statusTexts = SUPPORT_STATUS_TEXTS;
+const priorityTexts = SUPPORT_PRIORITY_TEXTS;
+
+type SupportTicketStatus = SupportTicketStatusKey;
+type SupportTicketPriority = SupportTicketPriorityKey;
+
+export async function GET(request: Request) {
+  const adminSession = await requireAdminSession();
+  if (!adminSession) {
+    return NextResponse.json({ message: "دسترسی غیرمجاز." }, { status: 403 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const statusParam = searchParams.get("status");
+    const priorityParam = searchParams.get("priority");
+    const searchTerm = searchParams.get("q");
+
+    const where: Prisma.SupportTicketWhereInput = {};
+
+    if (statusParam && statusTexts[statusParam as SupportTicketStatus]) {
+      where.status = statusParam as SupportTicketStatus;
+    }
+
+    if (priorityParam && priorityTexts[priorityParam as SupportTicketPriority]) {
+      where.priority = priorityParam as SupportTicketPriority;
+    }
+
+    if (searchTerm?.trim()) {
+      where.OR = [
+        { title: { contains: searchTerm.trim(), mode: "insensitive" } },
+        {
+          user: {
+            OR: [
+              { name: { contains: searchTerm.trim(), mode: "insensitive" } },
+              { email: { contains: searchTerm.trim(), mode: "insensitive" } },
+            ],
+          },
+        },
+      ];
+    }
+
+    const tickets = await prisma.supportTicket.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            avatarUrl: true,
+          },
+        },
+        messages: {
+          orderBy: { createdAt: "asc" },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                role: true,
+                avatarUrl: true,
+              },
+            },
+            attachments: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(
+      tickets.map((ticket) => ({
+        ...ticket,
+        statusLabel: statusTexts[ticket.status],
+        priorityLabel: priorityTexts[ticket.priority],
+      }))
+    );
+  } catch (error) {
+    console.error("ADMIN_SUPPORT_FETCH_ERROR", error);
+    return NextResponse.json(
+      { message: "خطا در دریافت تیکت‌های پشتیبانی." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/support/tickets/stream/route.ts
+++ b/src/app/api/admin/support/tickets/stream/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from "next/server";
+import type { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAdminSession } from "@/lib/admin-auth";
+import {
+  SUPPORT_PRIORITY_TEXTS,
+  SUPPORT_STATUS_TEXTS,
+  type SupportTicketPriorityKey,
+  type SupportTicketStatusKey,
+} from "@/lib/support";
+
+const encoder = new TextEncoder();
+
+const sendEvent = (controller: ReadableStreamDefaultController, data: unknown) => {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+};
+
+const sendHeartbeat = (controller: ReadableStreamDefaultController) => {
+  controller.enqueue(encoder.encode(`: keep-alive\n\n`));
+};
+
+const buildWhere = (
+  statusParam: string | null,
+  priorityParam: string | null,
+  searchTerm: string | null
+): Prisma.SupportTicketWhereInput => {
+  const where: Prisma.SupportTicketWhereInput = {};
+
+  if (statusParam && SUPPORT_STATUS_TEXTS[statusParam as SupportTicketStatusKey]) {
+    where.status = statusParam as SupportTicketStatusKey;
+  }
+
+  if (priorityParam && SUPPORT_PRIORITY_TEXTS[priorityParam as SupportTicketPriorityKey]) {
+    where.priority = priorityParam as SupportTicketPriorityKey;
+  }
+
+  if (searchTerm?.trim()) {
+    where.OR = [
+      { title: { contains: searchTerm.trim(), mode: "insensitive" } },
+      {
+        user: {
+          OR: [
+            { name: { contains: searchTerm.trim(), mode: "insensitive" } },
+            { email: { contains: searchTerm.trim(), mode: "insensitive" } },
+          ],
+        },
+      },
+    ];
+  }
+
+  return where;
+};
+
+const includeConfig = {
+  user: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      avatarUrl: true,
+    },
+  },
+  messages: {
+    orderBy: { createdAt: "asc" as const },
+    include: {
+      author: {
+        select: {
+          id: true,
+          name: true,
+          role: true,
+          avatarUrl: true,
+        },
+      },
+      attachments: true,
+    },
+  },
+} satisfies Prisma.SupportTicketInclude;
+
+const mapTicket = (ticket: Prisma.SupportTicketGetPayload<{ include: typeof includeConfig }>) => ({
+  ...ticket,
+  statusLabel: SUPPORT_STATUS_TEXTS[ticket.status],
+  priorityLabel: SUPPORT_PRIORITY_TEXTS[ticket.priority],
+});
+
+export async function GET(request: Request) {
+  const adminSession = await requireAdminSession();
+  if (!adminSession) {
+    return new NextResponse("Forbidden", { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const statusParam = searchParams.get("status");
+  const priorityParam = searchParams.get("priority");
+  const searchTerm = searchParams.get("q");
+  const where = buildWhere(statusParam, priorityParam, searchTerm);
+
+  let active = true;
+  let pollingTimer: NodeJS.Timeout | undefined;
+  let heartbeatTimer: NodeJS.Timeout | undefined;
+  let lastPayload = "";
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const pushSnapshot = async (force = false) => {
+        const tickets = await prisma.supportTicket.findMany({
+          where,
+          orderBy: { createdAt: "desc" },
+          include: includeConfig,
+        });
+        const mapped = tickets.map(mapTicket);
+        const serialized = JSON.stringify(mapped);
+        if (force || serialized !== lastPayload) {
+          lastPayload = serialized;
+          sendEvent(controller, mapped);
+        }
+      };
+
+      await pushSnapshot(true);
+
+      pollingTimer = setInterval(() => {
+        if (!active) return;
+        void pushSnapshot();
+      }, 5000);
+
+      heartbeatTimer = setInterval(() => {
+        if (!active) return;
+        sendHeartbeat(controller);
+      }, 15000);
+
+      const abort = () => {
+        active = false;
+        if (pollingTimer) clearInterval(pollingTimer);
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
+        controller.close();
+      };
+
+      request.signal.addEventListener("abort", abort);
+    },
+    cancel() {
+      active = false;
+      if (pollingTimer) clearInterval(pollingTimer);
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { getNotificationsSnapshot } from "@/lib/notifications";
+
+const encoder = new TextEncoder();
+
+const sendEvent = (controller: ReadableStreamDefaultController, data: unknown) => {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+};
+
+const sendHeartbeat = (controller: ReadableStreamDefaultController) => {
+  controller.enqueue(encoder.encode(`: keep-alive\n\n`));
+};
+
+export async function GET(request: Request) {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+    const userId = payload.userId as number;
+
+    let lastNotificationId: number | null = null;
+    let active = true;
+    let interval: NodeJS.Timeout | undefined;
+    let heartbeat: NodeJS.Timeout | undefined;
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        const pushSnapshot = async () => {
+          const snapshot = await getNotificationsSnapshot(userId);
+          if (snapshot.notifications.length > 0) {
+            lastNotificationId = snapshot.notifications[0]?.id ?? lastNotificationId;
+          }
+          sendEvent(controller, snapshot);
+        };
+
+        await pushSnapshot();
+
+        interval = setInterval(async () => {
+          if (!active) return;
+          const snapshot = await getNotificationsSnapshot(userId);
+          const newestId = snapshot.notifications[0]?.id ?? null;
+          if (newestId && newestId !== lastNotificationId) {
+            lastNotificationId = newestId;
+            sendEvent(controller, snapshot);
+          }
+        }, 5000);
+
+        heartbeat = setInterval(() => {
+          if (!active) return;
+          sendHeartbeat(controller);
+        }, 15000);
+
+        const abort = () => {
+          active = false;
+          clearInterval(interval);
+          if (heartbeat) {
+            clearInterval(heartbeat);
+          }
+          controller.close();
+        };
+
+        request.signal.addEventListener("abort", abort);
+      },
+      cancel() {
+        active = false;
+        if (interval) {
+          clearInterval(interval);
+        }
+        if (heartbeat) {
+          clearInterval(heartbeat);
+        }
+      },
+    });
+
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    console.error("NOTIFICATION_STREAM_ERROR", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/api/support/tickets/route.ts
+++ b/src/app/api/support/tickets/route.ts
@@ -1,0 +1,280 @@
+// src/app/api/support/tickets/route.ts
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { prisma } from "@/lib/prisma";
+import {
+  SUPPORT_STATUS_TEXTS,
+  SUPPORT_PRIORITY_TEXTS,
+  type SupportTicketPriorityKey,
+} from "@/lib/support";
+
+const MAX_ATTACHMENTS = 3;
+const MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_ATTACHMENT_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+const RATE_LIMIT_MAX_TICKETS = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+class SlidingWindowRateLimiter {
+  private readonly store = new Map<number, number[]>();
+
+  constructor(private readonly limit: number, private readonly windowMs: number) {}
+
+  consume(key: number):
+    | { allowed: true }
+    | { allowed: false; retryAfterMs: number } {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+    const timestamps = this.store.get(key) ?? [];
+    const recent = timestamps.filter((ts) => ts > windowStart);
+
+    if (recent.length >= this.limit) {
+      this.store.set(key, recent);
+      const retryAfterMs = recent[0] + this.windowMs - now;
+      return { allowed: false, retryAfterMs: Math.max(retryAfterMs, 0) };
+    }
+
+    recent.push(now);
+    this.store.set(key, recent);
+    return { allowed: true };
+  }
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __supportTicketRateLimiter: SlidingWindowRateLimiter | undefined;
+}
+
+const supportTicketRateLimiter =
+  globalThis.__supportTicketRateLimiter ??
+  (globalThis.__supportTicketRateLimiter = new SlidingWindowRateLimiter(
+    RATE_LIMIT_MAX_TICKETS,
+    RATE_LIMIT_WINDOW_MS
+  ));
+
+const statusTexts = SUPPORT_STATUS_TEXTS;
+const priorityTexts = SUPPORT_PRIORITY_TEXTS;
+
+type SupportTicketPriority = SupportTicketPriorityKey;
+
+interface AttachmentPayload {
+  url: string;
+  mimeType: string;
+  size: number;
+  filename?: string;
+}
+
+async function getAuthenticatedUserId() {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+    return typeof payload.userId === "number" ? payload.userId : null;
+  } catch (error) {
+    console.error("SUPPORT_TICKETS_AUTH_ERROR", error);
+    return null;
+  }
+}
+
+export async function GET() {
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json(
+      { message: "دسترسی غیرمجاز." },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const tickets = await prisma.supportTicket.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      include: {
+        messages: {
+          orderBy: { createdAt: "asc" },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                role: true,
+                avatarUrl: true,
+              },
+            },
+            attachments: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(
+      tickets.map((ticket) => ({
+        ...ticket,
+        statusLabel: statusTexts[ticket.status],
+        priorityLabel: priorityTexts[ticket.priority],
+      }))
+    );
+  } catch (error) {
+    console.error("SUPPORT_TICKETS_FETCH_ERROR", error);
+    return NextResponse.json(
+      { message: "خطا در دریافت تیکت‌ها." },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json(
+      { message: "دسترسی غیرمجاز." },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const title: string = body?.title;
+    const message: string = body?.message;
+    const priorityInput = body?.priority as SupportTicketPriority | undefined;
+    const attachmentsInput: AttachmentPayload[] = Array.isArray(body?.attachments)
+      ? body.attachments
+          .map((item: AttachmentPayload) => ({
+            url: typeof item?.url === "string" ? item.url : "",
+            mimeType: typeof item?.mimeType === "string" ? item.mimeType : "",
+            size: Number(item?.size) || 0,
+            filename: typeof item?.filename === "string" ? item.filename : undefined,
+          }))
+          .filter((item: AttachmentPayload) => item.url && item.mimeType && item.size > 0)
+      : [];
+
+    if (!title || !title.trim()) {
+      return NextResponse.json(
+        { message: "عنوان تیکت نمی‌تواند خالی باشد." },
+        { status: 400 }
+      );
+    }
+
+    if (!message || !message.trim()) {
+      return NextResponse.json(
+        { message: "متن پیام نمی‌تواند خالی باشد." },
+        { status: 400 }
+      );
+    }
+
+    if (priorityInput && !priorityTexts[priorityInput]) {
+      return NextResponse.json(
+        { message: "اولویت انتخاب‌شده معتبر نیست." },
+        { status: 400 }
+      );
+    }
+
+    if (attachmentsInput.length > MAX_ATTACHMENTS) {
+      return NextResponse.json(
+        {
+          message: `حداکثر ${MAX_ATTACHMENTS} پیوست برای هر تیکت مجاز است.`,
+        },
+        { status: 400 }
+      );
+    }
+
+    const invalidAttachment = attachmentsInput.find((item) => {
+      if (!ALLOWED_ATTACHMENT_MIME_TYPES.has(item.mimeType)) {
+        return true;
+      }
+      if (item.size <= 0 || item.size > MAX_ATTACHMENT_SIZE) {
+        return true;
+      }
+      return false;
+    });
+
+    if (invalidAttachment) {
+      return NextResponse.json(
+        {
+          message:
+            "پیوست نامعتبر است. تنها تصاویر JPEG، PNG یا WebP با حداکثر حجم ۵ مگابایت پذیرفته می‌شوند.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const rateAttempt = supportTicketRateLimiter.consume(userId);
+    if (!rateAttempt.allowed) {
+      const retryAfterMinutes = Math.max(
+        1,
+        Math.ceil(rateAttempt.retryAfterMs / 60000)
+      );
+      return NextResponse.json(
+        {
+          message: `به دلیل ثبت تیکت‌های متعدد، لطفاً پس از ${retryAfterMinutes} دقیقه دوباره تلاش کنید.`,
+        },
+        { status: 429 }
+      );
+    }
+
+    const ticket = await prisma.supportTicket.create({
+      data: {
+        title: title.trim(),
+        userId,
+        priority: priorityInput ?? "NORMAL",
+        messages: {
+          create: {
+            body: message.trim(),
+            authorId: userId,
+            authorRole: "USER",
+            attachments:
+              attachmentsInput.length > 0
+                ? {
+                    create: attachmentsInput.map((item) => ({
+                      url: item.url,
+                      mimeType: item.mimeType,
+                      size: item.size,
+                      filename: item.filename,
+                    })),
+                  }
+                : undefined,
+          },
+        },
+      },
+      include: {
+        messages: {
+          orderBy: { createdAt: "asc" },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                role: true,
+                avatarUrl: true,
+              },
+            },
+            attachments: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(
+      {
+        ...ticket,
+        statusLabel: statusTexts[ticket.status],
+        priorityLabel: priorityTexts[ticket.priority],
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("SUPPORT_TICKETS_CREATE_ERROR", error);
+    return NextResponse.json(
+      { message: "در ثبت تیکت خطایی رخ داد." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,7 +1,9 @@
 // src/app/api/upload/route.ts
-import { NextResponse } from 'next/server';
-import { v2 as cloudinary } from 'cloudinary';
-import sharp from 'sharp';
+import { NextResponse } from "next/server";
+import { v2 as cloudinary } from "cloudinary";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
 
 // پیکربندی Cloudinary با استفاده از متغیرهای محیطی
 cloudinary.config({
@@ -11,23 +13,58 @@ cloudinary.config({
   secure: true,
 });
 
+export const runtime = 'nodejs';
+
 export async function POST(req: Request) {
   const data = await req.formData();
-  const file: File | null = data.get('file') as unknown as File;
+  const file = data.get("file");
 
-  if (!file) {
-    return NextResponse.json({ success: false, error: "No file found" }, { status: 400 });
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { success: false, error: "فایلی برای آپلود ارسال نشده است." },
+      { status: 400 }
+    );
+  }
+
+  if (!ALLOWED_MIME_TYPES.includes(file.type as (typeof ALLOWED_MIME_TYPES)[number])) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "فرمت فایل پشتیبانی نمی‌شود. تنها فرمت‌های JPEG، PNG و WebP مجاز هستند.",
+      },
+      { status: 400 }
+    );
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "حجم فایل بیشتر از حد مجاز (۵ مگابایت) است.",
+      },
+      { status: 400 }
+    );
   }
 
   try {
     // ۱. خواندن فایل و تبدیل آن به بافر
     const bytes = await file.arrayBuffer();
-    const buffer = Buffer.from(bytes);
+    const buffer = Buffer.from(bytes) as Buffer;
 
-    // ۲. بهینه‌سازی تصویر با Sharp (اختیاری اما پیشنهادی)
-    const jpegBuffer = await sharp(buffer)
-      .jpeg({ quality: 80 })
-      .toBuffer();
+    // ۲. تلاش برای بهینه‌سازی تصویر با Sharp، در صورت موجود نبودن، بافر اصلی استفاده می‌شود
+    let optimizedBuffer = buffer;
+    const shouldOptimize = file.type === "image/jpeg";
+    if (shouldOptimize) {
+      try {
+        type SharpModule = typeof import("sharp");
+        const imported = await import("sharp");
+        const sharpFactory =
+          ((imported as unknown as { default?: SharpModule }).default ?? (imported as unknown as SharpModule));
+        optimizedBuffer = await sharpFactory(buffer).jpeg({ quality: 80 }).toBuffer();
+      } catch (optimizationError) {
+        console.warn("Sharp unavailable, skipping image optimization:", optimizationError);
+      }
+    }
 
     // ۳. آپلود بافر تصویر در Cloudinary به صورت استریم
     const uploadResult = await new Promise((resolve, reject) => {
@@ -45,7 +82,7 @@ export async function POST(req: Request) {
         }
       );
       // ارسال بافر به استریم
-      uploadStream.end(jpegBuffer);
+      uploadStream.end(optimizedBuffer);
     });
 
     // بررسی نوع نتیجه برای دسترسی امن به url
@@ -59,8 +96,11 @@ export async function POST(req: Request) {
     }
 
   } catch (error) {
-    console.error('Upload failed:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown upload error';
-    return NextResponse.json({ success: false, error: 'Upload failed', details: errorMessage }, { status: 500 });
+    console.error("Upload failed:", error);
+    const errorMessage = error instanceof Error ? error.message : "Unknown upload error";
+    return NextResponse.json(
+      { success: false, error: "آپلود فایل با خطا مواجه شد.", details: errorMessage },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -3,11 +3,34 @@ import { prisma } from "@/lib/prisma";
 import ArticleCard from "@/components/ArticleCard";
 import { Pagination } from "@/components/Pagination";
 
+const EXCERPT_LIMIT = 200;
+
+const extractPlainText = (html: string) =>
+  html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const buildExcerpt = (text: string, limit: number) => {
+  if (!text) return "";
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit).trimEnd()}…`;
+};
+
+const estimateReadTime = (stored: number | null | undefined, plainText: string) => {
+  if (stored && stored > 0) return stored;
+  const words = plainText.split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(words / 200));
+};
+
 const ARTICLES_PER_PAGE = 10;
 
 interface ArticlesPageProps {
   searchParams: {
     page?: string;
+    category?: string;
+    categoryId?: string;
   };
 }
 
@@ -17,13 +40,45 @@ const ArticlesPage = async ({ searchParams }: ArticlesPageProps) => {
     return <p className="text-center">شماره صفحه نامعتبر است.</p>;
   }
 
+  const { category, categoryId } = searchParams;
+  let activeCategoryTitle: string | null = null;
+
+  if (categoryId) {
+    const categoryRecord = await prisma.category.findUnique({
+      where: { id: Number(categoryId) },
+      select: { name: true },
+    });
+    activeCategoryTitle = categoryRecord?.name || null;
+  } else if (category) {
+    activeCategoryTitle = decodeURIComponent(category);
+  }
+
+  const categoryFilter = categoryId
+    ? {
+        categories: {
+          some: { id: Number(categoryId) },
+        },
+      }
+    : activeCategoryTitle
+    ? {
+        categories: {
+          some: { name: activeCategoryTitle },
+        },
+      }
+    : undefined;
+
+  const where = {
+    status: "APPROVED" as const,
+    ...(categoryFilter || {}),
+  };
+
   const totalArticles = await prisma.article.count({
-    where: { status: "APPROVED" },
+    where,
   });
   const totalPages = Math.ceil(totalArticles / ARTICLES_PER_PAGE);
 
   const articles = await prisma.article.findMany({
-    where: { status: "APPROVED" },
+    where,
     orderBy: { createdAt: "desc" },
     skip: (currentPage - 1) * ARTICLES_PER_PAGE,
     take: ARTICLES_PER_PAGE,
@@ -38,33 +93,38 @@ const ArticlesPage = async ({ searchParams }: ArticlesPageProps) => {
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-4xl font-bold text-center mb-8">
-          آخرین مقالات
+          {categoryFilter
+            ? `مقالات مرتبط با ${activeCategoryTitle?.trim() || "موضوع انتخابی"}`
+            : "آخرین مقالات"}
         </h1>
         {articles.length > 0 ? (
           <div className="space-y-6">
-            {articles.map((article) => (
-              <ArticleCard
-                key={article.id}
-                id={article.id.toString()}
-                title={article.title}
-                excerpt={
-                  article.content.substring(0, 200).replace(/<[^>]*>?/gm, "") +
-                  "..."
-                }
-                author={{
-                  name: article.author.name || "ناشناس",
-                  avatar: article.author.avatarUrl || undefined,
-                }}
-                readTime={article.readTimeMinutes || 1}
-                publishDate={new Intl.DateTimeFormat("fa-IR").format(
-                  new Date(article.createdAt)
-                )}
-                claps={article._count.claps}
-                comments={article._count.comments}
-                category={article.categories[0]?.name || "عمومی"}
-                image={article.coverImageUrl}
-              />
-            ))}
+            {articles.map((article) => {
+              const plainText = extractPlainText(article.content);
+              const excerpt = buildExcerpt(plainText, EXCERPT_LIMIT);
+              const readTime = estimateReadTime(article.readTimeMinutes, plainText);
+
+              return (
+                <ArticleCard
+                  key={article.id}
+                  id={article.id.toString()}
+                  title={article.title}
+                  excerpt={excerpt}
+                  author={{
+                    name: article.author.name || "ناشناس",
+                    avatar: article.author.avatarUrl || undefined,
+                  }}
+                  readTime={readTime}
+                  publishDate={new Intl.DateTimeFormat("fa-IR").format(
+                    new Date(article.createdAt)
+                  )}
+                  claps={article._count.claps}
+                  comments={article._count.comments}
+                  category={article.categories[0]?.name || "عمومی"}
+                  image={article.coverImageUrl}
+                />
+              );
+            })}
           </div>
         ) : (
           <p className="text-center text-muted-foreground py-16">

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,9 +1,9 @@
-"use client"; // اشتباه تایپی 'use-client' به "use client" اصلاح شد
-
-import { useState } from "react";
+// src/app/categories/page.tsx
+import { prisma } from "@/lib/prisma";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
 import {
   Laptop,
   History,
@@ -17,143 +17,149 @@ import {
   Leaf,
   BookOpen,
   Music,
+  LucideIcon,
 } from "lucide-react";
-import Link from "next/link";
-import Header from "@/components/Header";
-import Footer from "@/components/Footer";
 
-const Categories = () => {
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(
-    null
-  );
+type CategoryWithStats = {
+  id: number;
+  name: string;
+  slug: string;
+  description: string;
+  icon: LucideIcon;
+  color: string;
+  articleCount: number;
+};
 
-  const categories = [
-    {
-      id: "technology",
-      name: "فناوری",
-      icon: Laptop,
-      description: "آخرین اخبار و تحلیل‌های حوزه فناوری، هوش مصنوعی و نوآوری",
-      articleCount: 156,
-      color: "bg-blue-500",
-      featured: true,
-    },
-    {
-      id: "history",
-      name: "تاریخ",
-      icon: History,
-      description: "کاوش در تاریخ ایران و جهان، تمدن‌ها و وقایع مهم تاریخی",
-      articleCount: 89,
-      color: "bg-amber-500",
-      featured: true,
-    },
-    {
-      id: "art",
-      name: "هنر و معماری",
-      icon: Palette,
-      description: "هنر معاصر، معماری، طراحی و خلاقیت در ابعاد مختلف",
-      articleCount: 67,
-      color: "bg-purple-500",
-      featured: false,
-    },
-    {
-      id: "science",
-      name: "علم",
-      icon: FlaskConical,
-      description: "پیشرفت‌های علمی، تحقیقات جدید و کشفیات علمی",
-      articleCount: 98,
-      color: "bg-green-500",
-      featured: true,
-    },
-    {
-      id: "culture",
-      name: "فرهنگ",
-      icon: Globe,
-      description: "فرهنگ ایرانی و جهانی، آداب و رسوم، زندگی اجتماعی",
-      articleCount: 124,
-      color: "bg-rose-500",
-      featured: false,
-    },
-    {
-      id: "politics",
-      name: "سیاست",
-      icon: Building,
-      description: "تحلیل‌های سیاسی، رویدادهای داخلی و بین‌المللی",
-      articleCount: 78,
-      color: "bg-red-500",
-      featured: false,
-    },
-    {
-      id: "economy",
-      name: "اقتصاد",
-      icon: DollarSign,
-      description: "بازارهای مالی، اقتصاد ایران و جهان، استارتاپ‌ها",
-      articleCount: 92,
-      color: "bg-emerald-500",
-      featured: true,
-    },
-    {
-      id: "sports",
-      name: "ورزش",
-      icon: Dumbbell,
-      description: "اخبار ورزشی، تحلیل بازی‌ها و قهرمانان ورزشی",
-      articleCount: 45,
-      color: "bg-orange-500",
-      featured: false,
-    },
-    {
-      id: "health",
-      name: "سلامت",
-      icon: Heart,
-      description: "نکات سلامتی، پزشکی، تغذیه و سبک زندگی سالم",
-      articleCount: 73,
-      color: "bg-pink-500",
-      featured: false,
-    },
-    {
-      id: "environment",
-      name: "محیط زیست",
-      icon: Leaf,
-      description: "محیط زیست، تغییرات اقلیمی و حفاظت از طبیعت",
-      articleCount: 34,
-      color: "bg-teal-500",
-      featured: false,
-    },
-    {
-      id: "literature",
-      name: "ادبیات",
+const CATEGORY_METADATA: Record<string, { icon: LucideIcon; color: string; description: string }> = {
+  technology: {
+    icon: Laptop,
+    color: "bg-blue-500",
+    description: "آخرین نوآوری‌ها، هوش مصنوعی و آینده دنیای دیجیتال",
+  },
+  history: {
+    icon: History,
+    color: "bg-amber-500",
+    description: "سفر به گذشته و روایت تمدن‌های تاثیرگذار جهان",
+  },
+  art: {
+    icon: Palette,
+    color: "bg-purple-500",
+    description: "معماری، طراحی و الهامات خلاقانه هنرمندان",
+  },
+  science: {
+    icon: FlaskConical,
+    color: "bg-green-500",
+    description: "کشفیات تازه و تحلیل یافته‌های علمی",
+  },
+  culture: {
+    icon: Globe,
+    color: "bg-rose-500",
+    description: "جامعه، سبک زندگی و روایت‌های فرهنگی",
+  },
+  politics: {
+    icon: Building,
+    color: "bg-red-500",
+    description: "تحولات سیاسی ایران و جهان با نگاه تحلیلی",
+  },
+  economy: {
+    icon: DollarSign,
+    color: "bg-emerald-500",
+    description: "کسب‌وکارها، بازار سرمایه و اقتصاد هوشمند",
+  },
+  sports: {
+    icon: Dumbbell,
+    color: "bg-orange-500",
+    description: "اخبار، تحلیل مسابقات و پشت‌صحنه قهرمانان",
+  },
+  health: {
+    icon: Heart,
+    color: "bg-pink-500",
+    description: "پزشکی، تندرستی و سبک زندگی سالم",
+  },
+  environment: {
+    icon: Leaf,
+    color: "bg-teal-500",
+    description: "طبیعت، تغییرات اقلیمی و پایداری زیست‌بوم",
+  },
+  literature: {
+    icon: BookOpen,
+    color: "bg-indigo-500",
+    description: "کتاب‌ها، نقد ادبی و دنیای واژگان فارسی",
+  },
+  music: {
+    icon: Music,
+    color: "bg-violet-500",
+    description: "آهنگسازان، آلبوم‌های تازه و تحلیل سبک‌ها",
+  },
+};
+
+const FALLBACK_COLOR = "bg-slate-500";
+
+const createSlug = (name: string) =>
+  name
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^\u0600-\u06FF\w-]+/g, "");
+
+const getCategoryMetadata = (slug: string, name: string) => {
+  const fallbackDescription = `جدیدترین مقالات مرتبط با ${name}`;
+  const metadata = CATEGORY_METADATA[slug];
+
+  if (!metadata) {
+    return {
+      description: fallbackDescription,
       icon: BookOpen,
-      description: "شعر و ادب فارسی، نقد ادبی، کتاب‌خوانی",
-      articleCount: 87,
-      color: "bg-indigo-500",
-      featured: false,
-    },
-    {
-      id: "music",
-      name: "موسیقی",
-      icon: Music,
-      description: "موسیقی کلاسیک و مدرن، آموزش و تحلیل موسیقی",
-      articleCount: 29,
-      color: "bg-violet-500",
-      featured: false,
-    },
-  ];
+      color: FALLBACK_COLOR,
+    };
+  }
 
-  const featuredCategories = categories.filter((cat) => cat.featured);
-  const allCategories = categories;
+  return {
+    description: metadata.description,
+    icon: metadata.icon,
+    color: metadata.color,
+  };
+};
+
+const Categories = async () => {
+  const categoriesFromDb = await prisma.category.findMany({
+    orderBy: { name: "asc" },
+    include: {
+      articles: {
+        where: { status: "APPROVED" },
+        select: { id: true },
+      },
+    },
+  });
+
+  const categories: CategoryWithStats[] = categoriesFromDb.map((category) => {
+    const slug = createSlug(category.name);
+    const { color, description, icon } = getCategoryMetadata(slug, category.name);
+
+    return {
+      id: category.id,
+      name: category.name,
+      slug,
+      description,
+      icon,
+      color,
+      articleCount: category.articles.length,
+    };
+  });
+
+  const featuredCategories = [...categories]
+    .sort((a, b) => b.articleCount - a.articleCount)
+    .slice(0, 4);
 
   return (
     <div className="min-h-screen bg-background">
-
-
       {/* Hero Section */}
       <section className="py-16 bg-journal-cream/30">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
-            <h1 className="text-4xl font-bold text-journal mb-4">
-              دسته‌بندی مقالات
-            </h1>
+            <h1 className="text-4xl font-bold text-journal mb-4">دسته‌بندی مقالات</h1>
             <p className="text-xl text-journal-light mb-8">
-              موضوعات مختلف مجله روانیک را کاوش کنید
+              موضوعات مختلف مجله روانیک را با داده‌های زنده جست‌وجو کنید
             </p>
           </div>
         </div>
@@ -164,21 +170,19 @@ const Categories = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
             <h2 className="text-2xl font-bold text-journal mb-8 text-center">
-              دسته‌بندی‌های محبوب
+              پربازدیدترین موضوعات این هفته
             </h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
               {featuredCategories.map((category) => (
                 <Link
-                  href={`/articles?category=${category.id}`}
+                  href={`/articles?categoryId=${category.id}`}
                   key={category.id}
                 >
                   <Card className="group hover:shadow-medium transition-all duration-300 border-0 shadow-soft h-full">
                     <CardContent className="p-6 text-center">
                       <div className="flex justify-center mb-4">
-                        <div
-                          className={`p-4 ${category.color} text-white rounded-xl`}
-                        >
+                        <div className={`p-4 ${category.color} text-white rounded-xl`}>
                           <category.icon className="h-8 w-8" />
                         </div>
                       </div>
@@ -192,7 +196,7 @@ const Categories = () => {
                         variant="secondary"
                         className="bg-journal-cream text-journal-green"
                       >
-                        {category.articleCount} مقاله
+                        {category.articleCount.toLocaleString("fa-IR")} مقاله
                       </Badge>
                     </CardContent>
                   </Card>
@@ -208,21 +212,19 @@ const Categories = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
             <h2 className="text-2xl font-bold text-journal mb-8 text-center">
-              همه دسته‌بندی‌ها
+              همه موضوعات موجود
             </h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {allCategories.map((category) => (
+              {categories.map((category) => (
                 <Link
-                  href={`/articles?category=${category.id}`} // <-- 'to' به 'href' تغییر کرد
+                  href={`/articles?categoryId=${category.id}`}
                   key={category.id}
                 >
                   <Card className="group hover:shadow-medium transition-all duration-300 border-0 shadow-soft h-full">
                     <CardContent className="p-6">
                       <div className="flex items-start gap-4">
-                        <div
-                          className={`p-3 ${category.color} text-white rounded-lg flex-shrink-0`}
-                        >
+                        <div className={`p-3 ${category.color} text-white rounded-lg flex-shrink-0`}>
                           <category.icon className="h-6 w-6" />
                         </div>
                         <div className="flex-1">
@@ -237,16 +239,8 @@ const Categories = () => {
                               variant="secondary"
                               className="bg-journal-cream text-journal-green text-xs"
                             >
-                              {category.articleCount} مقاله
+                              {category.articleCount.toLocaleString("fa-IR")} مقاله
                             </Badge>
-                            {category.featured && (
-                              <Badge
-                                variant="outline"
-                                className="border-journal-orange text-journal-orange text-xs"
-                              >
-                                محبوب
-                              </Badge>
-                            )}
                           </div>
                         </div>
                       </div>
@@ -264,13 +258,13 @@ const Categories = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
             <h2 className="text-3xl font-bold text-journal mb-6">
-              موضوع مورد علاقه خود را پیدا نکردید؟
+              موضوع تازه‌ای مدنظر دارید؟
             </h2>
             <p className="text-xl text-journal-light mb-8">
-              پیشنهاد موضوع جدید دهید یا خودتان در آن حوزه مقاله بنویسید
+              به جمع نویسندگان بپیوندید یا پیشنهاد خود را برای ایجاد دسته‌بندی جدید ثبت کنید.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="/write"> {/* <-- 'to' به 'href' تغییر کرد */}
+              <Link href="/write">
                 <Button
                   size="lg"
                   className="bg-journal-green text-white hover:bg-journal-green-light"
@@ -278,7 +272,7 @@ const Categories = () => {
                   نوشتن مقاله
                 </Button>
               </Link>
-              <Link href="/contact"> {/* <-- 'to' به 'href' تغییر کرد */}
+              <Link href="/contact">
                 <Button
                   variant="outline"
                   size="lg"
@@ -291,7 +285,6 @@ const Categories = () => {
           </div>
         </div>
       </section>
-
     </div>
   );
 };

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,15 @@
+const OfflinePage = () => {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-journal-cream/40 text-center px-6">
+      <h1 className="text-3xl md:text-4xl font-bold text-journal mb-4">بدون اتصال اینترنت هستید</h1>
+      <p className="text-journal-light max-w-xl mb-8">
+        برای ادامه مطالعه به اینترنت متصل شوید. می‌توانید مقالات ذخیره شده در حافظه مرورگر را پس از اتصال مشاهده کنید.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        پس از برقراری اتصال، صفحه را تازه‌سازی کنید تا جدیدترین محتوا بارگذاری شود.
+      </p>
+    </div>
+  );
+};
+
+export default OfflinePage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,50 +1,70 @@
 // src/app/page.tsx
+import { prisma } from "@/lib/prisma";
 import { Button } from "@/components/ui/button";
 import { PenTool, BookOpen, Users } from "lucide-react";
 import Link from "next/link";
 import ArticleCard from "@/components/ArticleCard";
 import Logo from "@/components/Logo";
+import { formatDistanceToNow } from "date-fns";
+import { faIR } from "date-fns/locale";
 
-const Index = () => {
-  // Sample articles data
-  const featuredArticles = [
-    {
-      id: "1",
-      title: "هوش مصنوعی و آینده‌ای که در انتظار ماست",
-      excerpt: "بررسی تأثیرات هوش مصنوعی بر جامعه، اقتصاد و زندگی روزمره انسان‌ها. چگونه این فناوری جهان را تغییر خواهد داد؟",
-      author: { name: "علی رضایی", avatar: "" },
-      readTime: 8,
-      publishDate: "۳ روز پیش",
-      claps: 124, // <-- تغییر از likes به claps
-      comments: 23,
-      category: "فناوری",
-      image: ""
+export const dynamic = "force-dynamic";
+
+const Index = async () => {
+  const [articleCount, authorCount, dailyReadersCount] = await Promise.all([
+    prisma.article.count({ where: { status: "APPROVED" } }),
+    prisma.user.count({
+      where: {
+        articles: { some: { status: "APPROVED" } },
+      },
+    }),
+    prisma.articleView.count({
+      where: {
+        viewedAt: {
+          gte: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        },
+      },
+    }),
+  ]);
+
+  const featuredArticles = await prisma.article.findMany({
+    where: { status: "APPROVED" },
+    orderBy: [
+      { claps: { _count: "desc" } },
+      { views: { _count: "desc" } },
+      { createdAt: "desc" },
+    ],
+    take: 3,
+    include: {
+      author: { select: { name: true, avatarUrl: true } },
+      categories: { select: { name: true } },
+      _count: { select: { claps: true, comments: true } },
     },
-    {
-      id: "2",
-      title: "سفری به دل تاریخ ایران باستان",
-      excerpt: "کاوش در اعماق تمدن ایرانی و بررسی دستاوردهای باستانیان که هنوز در زندگی امروز ما تأثیرگذار هستند.",
-      author: { name: "مریم احمدی", avatar: "" },
-      readTime: 12,
-      publishDate: "یک هفته پیش",
-      claps: 89, // <-- تغییر از likes به claps
-      comments: 15,
-      category: "تاریخ",
-      image: ""
-    },
-    {
-      id: "3",
-      title: "روان‌شناسی رنگ‌ها در معماری مدرن",
-      excerpt: "تأثیر رنگ‌ها بر روحیه انسان و چگونگی استفاده از این دانش در طراحی فضاهای زندگی و کار.",
-      author: { name: "محمد حسینی", avatar: "" },
-      readTime: 6,
-      publishDate: "۲ هفته پیش",
-      claps: 67, // <-- تغییر از likes به claps
-      comments: 8,
-      category: "هنر و معماری",
-      image: ""
-    }
-  ];
+  });
+
+  const formattedArticles = featuredArticles.map((article) => {
+    const plainContent = article.content.replace(/<[^>]*>?/gm, "");
+    const publishDate = formatDistanceToNow(new Date(article.createdAt), {
+      addSuffix: true,
+      locale: faIR,
+    });
+
+    return {
+      id: article.id.toString(),
+      title: article.title,
+      excerpt: plainContent.substring(0, 180) + (plainContent.length > 180 ? "..." : ""),
+      author: {
+        name: article.author.name || "ناشناس",
+        avatar: article.author.avatarUrl || undefined,
+      },
+      readTime: article.readTimeMinutes || Math.max(1, Math.round(plainContent.length / 900)),
+      publishDate,
+      claps: article._count.claps,
+      comments: article._count.comments,
+      category: article.categories[0]?.name || "عمومی",
+      image: article.coverImageUrl,
+    };
+  });
 
   return (
     <>
@@ -91,16 +111,22 @@ const Index = () => {
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
             <div className="text-center">
-              <div className="text-3xl font-bold text-journal-green mb-2">۱۲۰۰+</div>
+              <div className="text-3xl font-bold text-journal-green mb-2">
+                {articleCount.toLocaleString("fa-IR")}
+              </div>
               <p className="text-journal-light">مقاله منتشر شده</p>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold text-journal-green mb-2">۳۵۰+</div>
+              <div className="text-3xl font-bold text-journal-green mb-2">
+                {authorCount.toLocaleString("fa-IR")}
+              </div>
               <p className="text-journal-light">نویسنده فعال</p>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold text-journal-green mb-2">۸۵۰۰+</div>
-              <p className="text-journal-light">خواننده روزانه</p>
+              <div className="text-3xl font-bold text-journal-green mb-2">
+                {dailyReadersCount.toLocaleString("fa-IR")}
+              </div>
+              <p className="text-journal-light">بازدید ۲۴ ساعت گذشته</p>
             </div>
           </div>
         </div>
@@ -116,11 +142,17 @@ const Index = () => {
             </p>
           </div>
 
-          <div className="max-w-4xl mx-auto space-y-6">
-            {featuredArticles.map((article) => (
-              <ArticleCard key={article.id} {...article} />
-            ))}
-          </div>
+          {formattedArticles.length > 0 ? (
+            <div className="max-w-4xl mx-auto space-y-6">
+              {formattedArticles.map((article) => (
+                <ArticleCard key={article.id} {...article} />
+              ))}
+            </div>
+          ) : (
+            <div className="max-w-3xl mx-auto text-center py-16 text-journal-light">
+              هنوز مقاله تایید شده‌ای برای نمایش وجود ندارد. اولین نفری باشید که می‌نویسد!
+            </div>
+          )}
 
           <div className="text-center mt-12">
             <Link href="/articles">

--- a/src/app/publications/page.tsx
+++ b/src/app/publications/page.tsx
@@ -1,93 +1,112 @@
-// src/app/publications/page.tsx
-'use client';
+import { prisma } from "@/lib/prisma";
+import { PublicationCard } from "@/components/PublicationCard";
+import { Card, CardContent } from "@/components/ui/card";
+import { Users, FileText, Sparkles } from "lucide-react";
 
-import { useQuery } from '@tanstack/react-query';
-import { PublicationCard } from '@/components/PublicationCard';
-import { Skeleton } from '@/components/ui/skeleton';
+const PublicationsPage = async () => {
+  const publications = await prisma.publication.findMany({
+    include: {
+      _count: { select: { members: true, articles: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
 
-interface Publication {
-    id: number;
-    name: string;
-    slug: string;
-    description: string | null;
-    avatarUrl: string | null;
-    _count: {
-        members: number;
-        articles: number;
-    };
-}
+  const totalPublications = publications.length;
+  const totalMembers = publications.reduce((sum, publication) => sum + publication._count.members, 0);
+  const totalArticles = publications.reduce((sum, publication) => sum + publication._count.articles, 0);
 
-// تابع برای دریافت لیست انتشارات از API
-const fetchPublications = async (): Promise<Publication[]> => {
-    const response = await fetch('/api/publications');
-    if (!response.ok) {
-        throw new Error('Failed to fetch publications');
-    }
-    return response.json();
-};
+  const featuredPublications = [...publications]
+    .sort((a, b) => b._count.articles - a._count.articles)
+    .slice(0, 3);
 
-const PublicationsPage = () => {
-    const { data: publications, isLoading, isError } = useQuery<Publication[]>({
-        queryKey: ['publications'],
-        queryFn: fetchPublications,
-    });
-
-    return (
-        <div className="min-h-screen bg-background">
-            <section className="py-16 bg-muted/20">
-                <div className="container mx-auto px-4">
-                    <div className="max-w-4xl mx-auto text-center">
-                        <h1 className="text-4xl font-bold text-foreground mb-4">
-                            انتشارات روانیک
-                        </h1>
-                        <p className="text-xl text-muted-foreground">
-                            مجموعه‌ای از بهترین مجلات تخصصی فارسی را دنبال کنید.
-                        </p>
-                    </div>
-                </div>
-            </section>
-
-            <section className="py-12">
-                <div className="container mx-auto px-4">
-                    <div className="max-w-6xl mx-auto">
-                        {isLoading ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                {[...Array(4)].map((_, i) => (
-                                    <Skeleton key={i} className="h-48 w-full" />
-                                ))}
-                            </div>
-                        ) : isError ? (
-                            <div className="text-center py-12">
-                                <p className="text-destructive text-lg">
-                                    خطا در دریافت اطلاعات. لطفاً دوباره تلاش کنید.
-                                </p>
-                            </div>
-                        ) : publications && publications.length > 0 ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                {publications.map((pub) => (
-                                    <PublicationCard
-                                        key={pub.id}
-                                        name={pub.name}
-                                        slug={pub.slug}
-                                        description={pub.description}
-                                        avatarUrl={pub.avatarUrl}
-                                        membersCount={pub._count.members}
-                                        articlesCount={pub._count.articles}
-                                    />
-                                ))}
-                            </div>
-                        ) : (
-                            <div className="text-center py-12">
-                                <p className="text-muted-foreground text-lg">
-                                    هنوز هیچ انتشاراتی ثبت نشده است.
-                                </p>
-                            </div>
-                        )}
-                    </div>
-                </div>
-            </section>
+  return (
+    <div className="min-h-screen bg-background">
+      <section className="py-16 bg-muted/20">
+        <div className="container mx-auto px-4">
+          <div className="max-w-5xl mx-auto text-center space-y-6">
+            <h1 className="text-4xl font-bold text-foreground">انتشارات روانیک</h1>
+            <p className="text-lg text-muted-foreground">
+              از نشریات تخصصی و جمعی روانیک بازدید کنید و با نویسندگان حرفه‌ای همکاری داشته باشید.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <Card className="border-0 shadow-soft">
+                <CardContent className="flex flex-col items-center gap-2 py-6">
+                  <Users className="h-8 w-8 text-journal-green" />
+                  <p className="text-sm text-muted-foreground">کل اعضای فعال</p>
+                  <span className="text-2xl font-bold">{totalMembers.toLocaleString("fa-IR")}</span>
+                </CardContent>
+              </Card>
+              <Card className="border-0 shadow-soft">
+                <CardContent className="flex flex-col items-center gap-2 py-6">
+                  <FileText className="h-8 w-8 text-journal-orange" />
+                  <p className="text-sm text-muted-foreground">مجموع مقالات منتشر شده</p>
+                  <span className="text-2xl font-bold">{totalArticles.toLocaleString("fa-IR")}</span>
+                </CardContent>
+              </Card>
+              <Card className="border-0 shadow-soft">
+                <CardContent className="flex flex-col items-center gap-2 py-6">
+                  <Sparkles className="h-8 w-8 text-journal" />
+                  <p className="text-sm text-muted-foreground">تعداد نشریات فعال</p>
+                  <span className="text-2xl font-bold">{totalPublications.toLocaleString("fa-IR")}</span>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
         </div>
-    );
+      </section>
+
+      {featuredPublications.length > 0 && (
+        <section className="py-12">
+          <div className="container mx-auto px-4">
+            <div className="max-w-5xl mx-auto">
+              <h2 className="text-2xl font-bold text-foreground mb-6 text-center">نشریات پیشنهادی</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {featuredPublications.map((publication) => (
+                  <PublicationCard
+                    key={publication.id}
+                    name={publication.name}
+                    slug={publication.slug}
+                    description={publication.description}
+                    avatarUrl={publication.avatarUrl}
+                    membersCount={publication._count.members}
+                    articlesCount={publication._count.articles}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="py-12">
+        <div className="container mx-auto px-4">
+          <div className="max-w-6xl mx-auto">
+            {publications.length > 0 ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {publications.map((publication) => (
+                  <PublicationCard
+                    key={publication.id}
+                    name={publication.name}
+                    slug={publication.slug}
+                    description={publication.description}
+                    avatarUrl={publication.avatarUrl}
+                    membersCount={publication._count.members}
+                    articlesCount={publication._count.articles}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-12">
+                <p className="text-muted-foreground text-lg">
+                  هنوز هیچ انتشاراتی ثبت نشده است.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
 };
 
 export default PublicationsPage;

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,16 @@
+// src/app/support/page.tsx
+import type { Metadata } from "next";
+import { SupportCenter } from "@/components/SupportCenter";
+
+export const metadata: Metadata = {
+  title: "پشتیبانی روانیک",
+  description: "ارسال و پیگیری تیکت‌های پشتیبانی در مجله روانیک",
+};
+
+export default function SupportPage() {
+  return (
+    <div className="container mx-auto max-w-4xl px-4 py-12">
+      <SupportCenter />
+    </div>
+  );
+}

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -6,15 +6,17 @@ import { AdminUsersTab } from './AdminUsersTab';
 import { AdminArticlesTab } from './AdminArticlesTab';
 import { AdminCommentsTab } from './AdminCommentsTab';
 import { AdminSubscriptionsTab } from './AdminSubscriptionsTab'; // <-- ایمپورت جدید
+import { AdminSupportTab } from './AdminSupportTab';
 
 export const AdminDashboard = () => {
   return (
     <Tabs defaultValue="users" className="w-full">
-      <TabsList className="grid w-full grid-cols-4">
+      <TabsList className="grid w-full grid-cols-5">
         <TabsTrigger value="users">کاربران</TabsTrigger>
         <TabsTrigger value="articles">مقالات</TabsTrigger>
         <TabsTrigger value="comments">نظرات</TabsTrigger>
         <TabsTrigger value="subscriptions">اشتراک‌ها</TabsTrigger> {/* <-- تب جدید */}
+        <TabsTrigger value="support">تیکت‌ها</TabsTrigger>
       </TabsList>
       <TabsContent value="users">
         <AdminUsersTab />
@@ -27,6 +29,9 @@ export const AdminDashboard = () => {
       </TabsContent>
       <TabsContent value="subscriptions">
         <AdminSubscriptionsTab /> {/* <-- محتوای تب جدید */}
+      </TabsContent>
+      <TabsContent value="support">
+        <AdminSupportTab />
       </TabsContent>
     </Tabs>
   );

--- a/src/components/AdminSupportTab.tsx
+++ b/src/components/AdminSupportTab.tsx
@@ -1,0 +1,532 @@
+// src/components/AdminSupportTab.tsx
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import type { SupportTicketPriorityKey, SupportTicketStatusKey } from "@/lib/support";
+
+interface SupportAuthor {
+  id: number;
+  name: string | null;
+  role: string | null;
+  avatarUrl: string | null;
+}
+
+interface SupportAttachment {
+  id: number;
+  url: string;
+  mimeType: string;
+  size: number;
+  filename: string | null;
+  createdAt: string;
+}
+
+interface SupportMessage {
+  id: number;
+  body: string;
+  authorRole: "USER" | "ADMIN";
+  createdAt: string;
+  author: SupportAuthor | null;
+  attachments: SupportAttachment[];
+}
+
+interface SupportTicket {
+  id: number;
+  title: string;
+  status: SupportTicketStatusKey;
+  statusLabel: string;
+  priority: SupportTicketPriorityKey;
+  priorityLabel: string;
+  createdAt: string;
+  updatedAt: string;
+  user: {
+    id: number;
+    name: string | null;
+    email: string;
+    avatarUrl: string | null;
+  };
+  messages: SupportMessage[];
+}
+
+const statusOptions: { value: SupportTicketStatusKey; label: string }[] = [
+  { value: "OPEN", label: "باز" },
+  { value: "ANSWERED", label: "پاسخ داده شده" },
+  { value: "CLOSED", label: "بسته شده" },
+];
+
+const priorityOptions: { value: SupportTicketPriorityKey; label: string }[] = [
+  { value: "HIGH", label: "فوری" },
+  { value: "NORMAL", label: "معمولی" },
+  { value: "LOW", label: "کم" },
+];
+
+const statusStyles: Record<SupportTicketStatusKey, string> = {
+  OPEN: "bg-blue-100 text-blue-800",
+  ANSWERED: "bg-green-100 text-green-800",
+  CLOSED: "bg-gray-200 text-gray-800",
+};
+
+const priorityStyles: Record<SupportTicketPriorityKey, string> = {
+  HIGH: "bg-red-100 text-red-800",
+  NORMAL: "bg-amber-100 text-amber-800",
+  LOW: "bg-slate-100 text-slate-800",
+};
+
+const priorityWeight: Record<SupportTicketPriorityKey, number> = {
+  HIGH: 3,
+  NORMAL: 2,
+  LOW: 1,
+};
+
+interface AdminTicketFilters {
+  status?: SupportTicketStatusKey;
+  priority?: SupportTicketPriorityKey;
+  search?: string;
+}
+
+const ALL_FILTER_VALUE = "ALL" as const;
+const NO_CHANGE_VALUE = "NONE" as const;
+
+type StatusFilterValue = SupportTicketStatusKey | typeof ALL_FILTER_VALUE;
+type PriorityFilterValue = SupportTicketPriorityKey | typeof ALL_FILTER_VALUE;
+type StatusUpdateValue = SupportTicketStatusKey | typeof NO_CHANGE_VALUE;
+type PriorityUpdateValue = SupportTicketPriorityKey | typeof NO_CHANGE_VALUE;
+
+async function fetchAdminTickets(filters: AdminTicketFilters): Promise<SupportTicket[]> {
+  const params = new URLSearchParams();
+  if (filters.status) params.set("status", filters.status);
+  if (filters.priority) params.set("priority", filters.priority);
+  if (filters.search) params.set("q", filters.search);
+
+  const response = await fetch(
+    `/api/admin/support/tickets${params.toString() ? `?${params.toString()}` : ""}`,
+    { credentials: "include" }
+  );
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ message: "خطای ناشناخته" }));
+    throw new Error(payload?.message ?? "دریافت تیکت‌ها با خطا مواجه شد.");
+  }
+  return response.json();
+}
+
+interface ReplyInput {
+  ticketId: number;
+  message?: string;
+  status?: SupportTicketStatusKey;
+  priority?: SupportTicketPriorityKey;
+}
+
+async function replyToTicket(input: ReplyInput): Promise<SupportTicket> {
+  const response = await fetch(`/api/admin/support/tickets/${input.ticketId}/reply`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message: input.message, status: input.status, priority: input.priority }),
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ message: "خطای ناشناخته" }));
+    throw new Error(payload?.message ?? "ارسال پاسخ انجام نشد.");
+  }
+
+  return response.json();
+}
+
+export const AdminSupportTab = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
+  const [replyMessage, setReplyMessage] = useState("");
+  const [nextStatus, setNextStatus] = useState<StatusUpdateValue>(NO_CHANGE_VALUE);
+  const [nextPriority, setNextPriority] = useState<PriorityUpdateValue>(NO_CHANGE_VALUE);
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>(ALL_FILTER_VALUE);
+  const [priorityFilter, setPriorityFilter] = useState<PriorityFilterValue>(ALL_FILTER_VALUE);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const sseErrorShownRef = useRef(false);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedSearch(searchTerm.trim());
+    }, 400);
+    return () => clearTimeout(handle);
+  }, [searchTerm]);
+
+  const filters = useMemo<AdminTicketFilters>(
+    () => ({
+      status: statusFilter === ALL_FILTER_VALUE ? undefined : statusFilter,
+      priority: priorityFilter === ALL_FILTER_VALUE ? undefined : priorityFilter,
+      search: debouncedSearch || undefined,
+    }),
+    [statusFilter, priorityFilter, debouncedSearch]
+  );
+
+  const filtersKey = useMemo(
+    () =>
+      JSON.stringify({
+        status: filters.status ?? ALL_FILTER_VALUE,
+        priority: filters.priority ?? ALL_FILTER_VALUE,
+        search: filters.search ?? "",
+      }),
+    [filters]
+  );
+
+  const {
+    data: tickets,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["admin", "supportTickets", filtersKey],
+    queryFn: () => fetchAdminTickets(filters),
+  });
+
+  const replyMutation = useMutation({
+    mutationFn: replyToTicket,
+    onSuccess: () => {
+      toast({
+        title: "پاسخ ثبت شد",
+        description: "پیام شما برای کاربر ارسال شد.",
+      });
+      setReplyMessage("");
+      setNextStatus(NO_CHANGE_VALUE);
+      setNextPriority(NO_CHANGE_VALUE);
+      queryClient.invalidateQueries({ queryKey: ["admin", "supportTickets"] });
+    },
+    onError: (err: unknown) => {
+      const description = err instanceof Error ? err.message : "لطفاً دوباره تلاش کنید.";
+      toast({
+        variant: "destructive",
+        title: "خطا در ثبت پاسخ",
+        description,
+      });
+    },
+  });
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (filters.status) params.set("status", filters.status);
+    if (filters.priority) params.set("priority", filters.priority);
+    if (filters.search) params.set("q", filters.search);
+
+    const source = new EventSource(
+      `/api/admin/support/tickets/stream${params.toString() ? `?${params.toString()}` : ""}`
+    );
+
+    source.onmessage = (event) => {
+      const payload = JSON.parse(event.data) as SupportTicket[];
+      queryClient.setQueryData(["admin", "supportTickets", filtersKey], payload);
+      sseErrorShownRef.current = false;
+    };
+
+    source.onerror = () => {
+      if (!sseErrorShownRef.current) {
+        toast({
+          variant: "destructive",
+          title: "ارتباط زنده قطع شد",
+          description: "در حال تلاش برای برقراری مجدد ارتباط با سرور هستیم.",
+        });
+        sseErrorShownRef.current = true;
+      }
+    };
+
+    return () => {
+      source.close();
+    };
+  }, [filters, filtersKey, queryClient, toast]);
+
+  const orderedTickets = useMemo(() => {
+    if (!tickets) return [];
+    return [...tickets].sort((a, b) => {
+      const priorityDiff = priorityWeight[b.priority] - priorityWeight[a.priority];
+      if (priorityDiff !== 0) {
+        return priorityDiff;
+      }
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+  }, [tickets]);
+
+  useEffect(() => {
+    if (!selectedTicketId && orderedTickets.length > 0) {
+      setSelectedTicketId(orderedTickets[0].id);
+    }
+  }, [orderedTickets, selectedTicketId]);
+
+  const selectedTicket = useMemo(() => {
+    if (!selectedTicketId) return null;
+    return orderedTickets.find((ticket) => ticket.id === selectedTicketId) ?? null;
+  }, [orderedTickets, selectedTicketId]);
+
+  const handleReply = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedTicket) {
+      toast({ variant: "destructive", title: "ابتدا یک تیکت را انتخاب کنید." });
+      return;
+    }
+
+    const hasStatusChange = nextStatus !== NO_CHANGE_VALUE;
+    const hasPriorityChange = nextPriority !== NO_CHANGE_VALUE;
+
+    if (!replyMessage.trim() && !hasStatusChange && !hasPriorityChange) {
+      toast({
+        variant: "destructive",
+        title: "اطلاعات ناقص",
+        description: "لطفاً متن پاسخ، وضعیت یا اولویت جدید را مشخص کنید.",
+      });
+      return;
+    }
+
+    replyMutation.mutate({
+      ticketId: selectedTicket.id,
+      message: replyMessage.trim() || undefined,
+      status: hasStatusChange ? nextStatus : undefined,
+      priority: hasPriorityChange ? nextPriority : undefined,
+    });
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle>لیست تیکت‌ها</CardTitle>
+          <div className="mt-4 grid gap-3">
+            <div className="grid grid-cols-2 gap-2">
+              <Select
+                value={statusFilter}
+                onValueChange={(value) => setStatusFilter(value as StatusFilterValue)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="وضعیت: همه" />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  <SelectItem value={ALL_FILTER_VALUE}>همه وضعیت‌ها</SelectItem>
+                  {statusOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select
+                value={priorityFilter}
+                onValueChange={(value) => setPriorityFilter(value as PriorityFilterValue)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="اولویت: همه" />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  <SelectItem value={ALL_FILTER_VALUE}>همه اولویت‌ها</SelectItem>
+                  {priorityOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Input
+              placeholder="جستجو در عنوان یا کاربر"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+            />
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="space-y-3 p-4">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : isError ? (
+            <div className="p-6 text-sm text-destructive">
+              {error instanceof Error ? error.message : "خطا در دریافت تیکت‌ها."}
+            </div>
+          ) : orderedTickets.length === 0 ? (
+            <div className="p-6 text-sm text-muted-foreground">هنوز تیکتی ثبت نشده است.</div>
+          ) : (
+            <ScrollArea className="h-[520px]">
+              <div className="divide-y">
+                {orderedTickets.map((ticket) => (
+                  <button
+                    key={ticket.id}
+                    onClick={() => setSelectedTicketId(ticket.id)}
+                    className={`flex w-full flex-col items-start gap-2 border-r-4 px-4 py-3 text-right transition ${
+                      selectedTicketId === ticket.id ? "bg-muted" : "hover:bg-muted/60"
+                    } ${
+                      ticket.priority === "HIGH"
+                        ? "border-red-500"
+                        : ticket.priority === "NORMAL"
+                        ? "border-amber-400"
+                        : "border-transparent"
+                    }`}
+                  >
+                    <div className="flex w-full items-center justify-between">
+                      <span className="text-sm font-semibold text-journal">{ticket.title}</span>
+                      <div className="flex items-center gap-2">
+                        <Badge className={priorityStyles[ticket.priority]}>{ticket.priorityLabel}</Badge>
+                        <Badge className={statusStyles[ticket.status]}>{ticket.statusLabel}</Badge>
+                      </div>
+                    </div>
+                    <div className="flex w-full items-center justify-between text-xs text-muted-foreground">
+                      <span>{ticket.user.name || ticket.user.email}</span>
+                      <span>
+                        {new Intl.DateTimeFormat("fa-IR", {
+                          dateStyle: "short",
+                          timeStyle: "short",
+                        }).format(new Date(ticket.createdAt))}
+                      </span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle>جزئیات تیکت</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {!selectedTicket ? (
+            <div className="text-sm text-muted-foreground">
+              یکی از تیکت‌های سمت راست را انتخاب کنید تا مکاتبات نمایش داده شود.
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <p className="text-lg font-semibold text-journal">{selectedTicket.title}</p>
+                    <p className="text-sm text-muted-foreground">
+                      توسط {selectedTicket.user.name || selectedTicket.user.email}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge className={priorityStyles[selectedTicket.priority]}>
+                      {selectedTicket.priorityLabel}
+                    </Badge>
+                    <Badge className={statusStyles[selectedTicket.status]}>{selectedTicket.statusLabel}</Badge>
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  تاریخ ثبت: {new Intl.DateTimeFormat("fa-IR", { dateStyle: "full", timeStyle: "short" }).format(
+                    new Date(selectedTicket.createdAt)
+                  )}
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                <h3 className="text-sm font-semibold text-journal">مکالمه</h3>
+                <div className="space-y-3">
+                  {selectedTicket.messages.map((message) => (
+                    <div
+                      key={message.id}
+                      className={`rounded-lg border border-border p-4 ${
+                        message.authorRole === "ADMIN" ? "bg-muted" : "bg-background"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-semibold text-journal">
+                          {message.authorRole === "ADMIN" ? "پشتیبانی" : message.author?.name || "کاربر"}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {new Intl.DateTimeFormat("fa-IR", {
+                            dateStyle: "short",
+                            timeStyle: "short",
+                          }).format(new Date(message.createdAt))}
+                        </span>
+                      </div>
+                      <p className="mt-3 text-sm leading-7 text-journal-light">{message.body}</p>
+                      {message.attachments.length > 0 && (
+                        <div className="mt-3 space-y-2">
+                          <span className="text-xs font-medium text-muted-foreground">پیوست‌ها</span>
+                          <ul className="space-y-1 text-sm">
+                            {message.attachments.map((attachment) => (
+                              <li key={attachment.id}>
+                                <a
+                                  href={attachment.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-primary underline-offset-2 hover:underline"
+                                >
+                                  {attachment.filename || "دانلود فایل"}
+                                </a>
+                                <span className="mr-2 text-xs text-muted-foreground">
+                                  ({Math.max(1, Math.round(attachment.size / 1024))} کیلوبایت)
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <form className="space-y-4" onSubmit={handleReply}>
+                <div className="grid gap-2 md:grid-cols-2">
+                  <Select value={nextStatus} onValueChange={(value) => setNextStatus(value as StatusUpdateValue)}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="تغییر وضعیت" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={NO_CHANGE_VALUE}>بدون تغییر وضعیت</SelectItem>
+                      {statusOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select
+                    value={nextPriority}
+                    onValueChange={(value) => setNextPriority(value as PriorityUpdateValue)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="تغییر اولویت" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={NO_CHANGE_VALUE}>بدون تغییر اولویت</SelectItem>
+                      {priorityOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-journal">پاسخ پشتیبانی</label>
+                  <Textarea
+                    rows={4}
+                    value={replyMessage}
+                    onChange={(event) => setReplyMessage(event.target.value)}
+                    placeholder="پاسخ خود را برای کاربر بنویسید..."
+                  />
+                </div>
+                <div className="flex justify-end">
+                  <Button type="submit" disabled={replyMutation.isPending}>
+                    {replyMutation.isPending ? "در حال ارسال..." : "ارسال پاسخ"}
+                  </Button>
+                </div>
+              </form>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,6 +41,9 @@ const Header = () => {
             <Link href="/categories" className="text-journal-light hover:text-journal transition-colors">
               دسته‌بندی‌ها
             </Link>
+            <Link href="/support" className="text-journal-light hover:text-journal transition-colors">
+              پشتیبانی
+            </Link>
             <Link href="/about" className="text-journal-light hover:text-journal transition-colors">
               درباره ما
             </Link>
@@ -89,6 +92,9 @@ const Header = () => {
                     </Link>
                     <Link href="/categories" onClick={handleLinkClick} className="text-lg text-journal-light hover:text-journal transition-colors">
                       دسته‌بندی‌ها
+                    </Link>
+                    <Link href="/support" onClick={handleLinkClick} className="text-lg text-journal-light hover:text-journal transition-colors">
+                      پشتیبانی
                     </Link>
                     <Link href="/about" onClick={handleLinkClick} className="text-lg text-journal-light hover:text-journal transition-colors">
                       درباره ما

--- a/src/components/ProfileClient.tsx
+++ b/src/components/ProfileClient.tsx
@@ -1,22 +1,30 @@
 // src/components/ProfileClient.tsx
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
-import { Edit3, LogOut, Crown, Loader2, Pin, PinOff, History } from "lucide-react";
+import { Edit3, LogOut, Crown, Loader2, Pin, PinOff, History, Download } from "lucide-react";
 import ArticleCard from "@/components/ArticleCard";
 import { useRouter } from "next/navigation";
 import { ProfileSettings } from "./ProfileSettings";
 import { DeleteArticleButton } from "./DeleteArticleButton";
 import { Skeleton } from "./ui/skeleton";
 import { AnalyticsDashboard } from "./AnalyticsDashboard";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, QueryFunctionContext } from "@tanstack/react-query";
 import { Prisma } from "@prisma/client";
 import { useToast } from "@/components/ui/use-toast";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 // =======================================================================
 //  1. تعریف تایپ‌ها (Types)
@@ -30,6 +38,27 @@ type FetchedArticle = Prisma.ArticleGetPayload<{
     categories: { select: { name: true } };
   }
 }>;
+
+type ReadingHistoryItem = {
+  viewedAt: string;
+  article: FetchedArticle;
+};
+
+type HistoryFilters = {
+  search?: string;
+  range: string;
+  categoryId?: number | null;
+};
+
+type HistoryQueryKey = readonly ["readingHistory", HistoryFilters];
+
+const HISTORY_RANGE_LABELS: Record<string, string> = {
+  "7d": "۷ روز اخیر",
+  "30d": "۳۰ روز اخیر",
+  "90d": "۹۰ روز اخیر",
+  "365d": "۱ سال اخیر",
+  all: "همه زمان‌ها",
+};
 
 // تایپ اصلی برای داده‌های کاربر که از صفحه سرور می‌آید
 type UserPayload = Prisma.UserGetPayload<{
@@ -87,8 +116,28 @@ const pinArticleRequest = async (articleId: number | null) => {
   return response.json();
 };
 
-const fetchReadingHistory = async (): Promise<FetchedArticle[]> => {
-  const response = await fetch("/api/me/reading-history");
+const fetchReadingHistory = async (
+  { queryKey }: QueryFunctionContext<HistoryQueryKey>
+): Promise<ReadingHistoryItem[]> => {
+  const [, params] = queryKey;
+  const urlParams = new URLSearchParams();
+
+  if (params.search) {
+    urlParams.set("q", params.search);
+  }
+
+  if (params.range) {
+    urlParams.set("range", params.range);
+  }
+
+  if (params.categoryId) {
+    urlParams.set("categoryId", params.categoryId.toString());
+  }
+
+  const queryString = urlParams.toString();
+  const response = await fetch(
+    `/api/me/reading-history${queryString ? `?${queryString}` : ""}`
+  );
   if (!response.ok) throw new Error("Failed to fetch reading history");
   return response.json();
 };
@@ -154,6 +203,50 @@ export const ProfileClient = ({ user }: ProfileClientProps) => {
   const queryClient = useQueryClient();
 
   const [pinnedArticleId, setPinnedArticleId] = useState(user.pinnedArticleId);
+  const [historyRange, setHistoryRange] = useState("30d");
+  const [historySearch, setHistorySearch] = useState("");
+  const [debouncedHistorySearch, setDebouncedHistorySearch] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedHistorySearch(historySearch.trim());
+    }, 400);
+
+    return () => clearTimeout(timer);
+  }, [historySearch]);
+
+  const historyFilters = useMemo<HistoryFilters>(
+    () => ({
+      search: debouncedHistorySearch || undefined,
+      range: historyRange,
+    }),
+    [debouncedHistorySearch, historyRange]
+  );
+
+  const historyQueryKey = useMemo<HistoryQueryKey>(
+    () => ["readingHistory", historyFilters],
+    [historyFilters]
+  );
+
+  const currentRangeLabel = HISTORY_RANGE_LABELS[historyRange] ?? HISTORY_RANGE_LABELS["30d"];
+
+  const handleExportHistory = () => {
+    const params = new URLSearchParams();
+    if (debouncedHistorySearch) {
+      params.set("q", debouncedHistorySearch);
+    }
+    if (historyRange) {
+      params.set("range", historyRange);
+    }
+
+    const queryString = params.toString();
+    if (typeof window !== "undefined") {
+      window.open(
+        `/api/me/reading-history/export${queryString ? `?${queryString}` : ""}`,
+        "_blank"
+      );
+    }
+  };
 
   const { data: savedArticles, isLoading: isLoadingSaved, isError: isErrorSaved } = useQuery<FetchedArticle[]>({
     queryKey: ['savedArticles'],
@@ -167,10 +260,14 @@ export const ProfileClient = ({ user }: ProfileClientProps) => {
     enabled: activeTab === 'clapped',
   });
 
-  const { data: historyArticles, isLoading: isLoadingHistory, isError: isErrorHistory } = useQuery<FetchedArticle[]>({
-    queryKey: ['readingHistory'],
+  const {
+    data: historyArticles,
+    isLoading: isLoadingHistory,
+    isError: isErrorHistory,
+  } = useQuery<ReadingHistoryItem[], Error, ReadingHistoryItem[], HistoryQueryKey>({
+    queryKey: historyQueryKey,
     queryFn: fetchReadingHistory,
-    enabled: activeTab === 'history',
+    enabled: activeTab === "history",
   });
 
   const pinMutation = useMutation({
@@ -319,32 +416,89 @@ export const ProfileClient = ({ user }: ProfileClientProps) => {
                 <Card className="shadow-soft border-0">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2"><History className="h-5 w-5" />تاریخچه مطالعه</CardTitle>
-                    <CardDescription>آخرین مقالاتی که مطالعه کرده‌اید.</CardDescription>
+                    <CardDescription>
+                      آخرین مقالاتی که مطالعه کرده‌اید. نتایج را بر اساس بازه زمانی یا جست‌وجوی متن محدود کنید.
+                    </CardDescription>
                   </CardHeader>
                   <CardContent>
+                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+                      <Input
+                        value={historySearch}
+                        onChange={(event) => setHistorySearch(event.target.value)}
+                        placeholder="جست‌وجو بر اساس عنوان یا محتوای مقاله"
+                        className="md:max-w-sm"
+                      />
+                      <div className="flex items-center gap-2">
+                        <Select value={historyRange} onValueChange={setHistoryRange}>
+                          <SelectTrigger className="w-32">
+                            <SelectValue placeholder="بازه" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="7d">۷ روز اخیر</SelectItem>
+                            <SelectItem value="30d">۳۰ روز اخیر</SelectItem>
+                            <SelectItem value="90d">۹۰ روز اخیر</SelectItem>
+                            <SelectItem value="365d">۱ سال اخیر</SelectItem>
+                            <SelectItem value="all">همه زمان‌ها</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <Button
+                          variant="outline"
+                          onClick={handleExportHistory}
+                          disabled={isLoadingHistory || (historyArticles?.length ?? 0) === 0}
+                        >
+                          <Download className="ml-2 h-4 w-4" />
+                          خروجی CSV
+                        </Button>
+                      </div>
+                    </div>
                     {isLoadingHistory ? (
                       <div className="space-y-4"><Skeleton className="h-24 w-full" /><Skeleton className="h-24 w-full" /></div>
                     ) : isErrorHistory ? (
                       <p className="text-red-500 text-center">خطا در دریافت تاریخچه مطالعه.</p>
                     ) : historyArticles && historyArticles.length > 0 ? (
                       <div className="space-y-6">
-                        {historyArticles.map((article) => (
-                          <ArticleCard
-                            key={article.id}
-                            id={article.id.toString()}
-                            title={article.title}
-                            excerpt={article.content.substring(0, 150) + "..."}
-                            image={article.coverImageUrl}
-                            author={{ name: article.author.name || "ناشناس", avatar: article.author.avatarUrl }}
-                            readTime={article.readTimeMinutes || 1}
-                            publishDate={new Intl.DateTimeFormat("fa-IR").format(new Date(article.createdAt))}
-                            claps={article._count.claps}
-                            comments={article._count.comments}
-                            category={article.categories[0]?.name || "عمومی"}
-                          />
-                        ))}
+                        {historyArticles.map(({ article, viewedAt }) => {
+                          const plainContent = article.content.replace(/<[^>]*>?/gm, "");
+                          const preview = plainContent.substring(0, 150);
+                          const excerpt = preview + (plainContent.length > 150 ? "..." : "");
+
+                          return (
+                            <div key={`${article.id}-${viewedAt}`} className="space-y-2">
+                              <ArticleCard
+                                id={article.id.toString()}
+                                title={article.title}
+                                excerpt={excerpt}
+                                image={article.coverImageUrl}
+                                author={{
+                                  name: article.author.name || "ناشناس",
+                                  avatar: article.author.avatarUrl,
+                                }}
+                                readTime={article.readTimeMinutes || 1}
+                                publishDate={new Intl.DateTimeFormat("fa-IR").format(
+                                  new Date(article.createdAt)
+                                )}
+                                claps={article._count.claps}
+                                comments={article._count.comments}
+                                category={article.categories[0]?.name || "عمومی"}
+                              />
+                              <div className="flex justify-between text-xs text-muted-foreground px-2">
+                                <span>
+                                  آخرین مطالعه: {new Intl.DateTimeFormat("fa-IR", {
+                                    dateStyle: "medium",
+                                    timeStyle: "short",
+                                  }).format(new Date(viewedAt))}
+                                </span>
+                                <span>بازه فعال: {currentRangeLabel}</span>
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
-                    ) : (<p className="text-center text-muted-foreground py-8">تاریخچه مطالعه شما خالی است.</p>)}
+                    ) : (
+                      <p className="text-center text-muted-foreground py-8">
+                        تاریخچه مطالعه شما خالی است.
+                      </p>
+                    )}
                   </CardContent>
                 </Card>
               </TabsContent>

--- a/src/components/SupportCenter.tsx
+++ b/src/components/SupportCenter.tsx
@@ -1,0 +1,455 @@
+// src/components/SupportCenter.tsx
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { SupportTicketPriorityKey } from "@/lib/support";
+
+interface SupportAuthor {
+  id: number;
+  name: string | null;
+  role: string | null;
+  avatarUrl: string | null;
+}
+
+interface SupportAttachment {
+  id: number;
+  url: string;
+  mimeType: string;
+  size: number;
+  filename: string | null;
+  createdAt: string;
+}
+
+interface SupportMessage {
+  id: number;
+  body: string;
+  authorRole: "USER" | "ADMIN";
+  createdAt: string;
+  author: SupportAuthor | null;
+  attachments: SupportAttachment[];
+}
+
+interface SupportTicket {
+  id: number;
+  title: string;
+  status: "OPEN" | "ANSWERED" | "CLOSED";
+  statusLabel: string;
+  priority: SupportTicketPriorityKey;
+  priorityLabel: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: SupportMessage[];
+}
+
+const statusStyles: Record<SupportTicket["status"], string> = {
+  OPEN: "bg-blue-100 text-blue-800",
+  ANSWERED: "bg-green-100 text-green-800",
+  CLOSED: "bg-gray-200 text-gray-800",
+};
+
+const statusDescriptions: Record<SupportTicket["status"], string> = {
+  OPEN: "در انتظار بررسی تیم پشتیبانی",
+  ANSWERED: "پاسخ از سوی تیم پشتیبانی ثبت شده است",
+  CLOSED: "این تیکت بسته شده است",
+};
+
+const priorityOptions: { value: SupportTicketPriorityKey; label: string; description: string }[] = [
+  { value: "HIGH", label: "فوری", description: "رسیدگی در سریع‌ترین زمان ممکن" },
+  { value: "NORMAL", label: "معمولی", description: "رسیدگی در نوبت استاندارد" },
+  { value: "LOW", label: "کم", description: "پیشنهاد یا درخواست غیر فوری" },
+];
+
+const priorityStyles: Record<SupportTicketPriorityKey, string> = {
+  HIGH: "bg-red-100 text-red-800",
+  NORMAL: "bg-amber-100 text-amber-800",
+  LOW: "bg-slate-100 text-slate-800",
+};
+
+const priorityWeight: Record<SupportTicketPriorityKey, number> = {
+  HIGH: 3,
+  NORMAL: 2,
+  LOW: 1,
+};
+
+const MAX_ATTACHMENTS = 3;
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+async function fetchTickets(): Promise<SupportTicket[]> {
+  const response = await fetch("/api/support/tickets");
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ message: "خطای ناشناخته" }));
+    throw new Error(payload?.message ?? "خطا در دریافت تیکت‌ها");
+  }
+  return response.json();
+}
+
+interface TicketAttachmentPayload {
+  url: string;
+  mimeType: string;
+  size: number;
+  filename?: string;
+}
+
+interface CreateTicketInput {
+  title: string;
+  message: string;
+  priority: SupportTicketPriorityKey;
+  attachments: TicketAttachmentPayload[];
+}
+
+async function createTicket(input: CreateTicketInput): Promise<SupportTicket> {
+  const response = await fetch("/api/support/tickets", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ message: "خطای ناشناخته" }));
+    throw new Error(payload?.message ?? "ثبت تیکت با خطا مواجه شد");
+  }
+
+  return response.json();
+}
+
+async function uploadAttachment(file: File): Promise<TicketAttachmentPayload> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetch("/api/upload", {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ error: "خطای ناشناخته" }));
+    throw new Error(payload?.error ?? "آپلود فایل ناموفق بود");
+  }
+
+  const { url } = (await response.json()) as { url?: string };
+  if (!url) {
+    throw new Error("آدرس فایل بارگذاری‌شده دریافت نشد.");
+  }
+  return {
+    url,
+    mimeType: file.type,
+    size: file.size,
+    filename: file.name,
+  };
+}
+
+export const SupportCenter = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+  const [priority, setPriority] = useState<SupportTicketPriorityKey>("NORMAL");
+  const [files, setFiles] = useState<File[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const { data: tickets, isLoading, isError, error } = useQuery({
+    queryKey: ["supportTickets"],
+    queryFn: fetchTickets,
+  });
+
+  const createTicketMutation = useMutation({
+    mutationFn: createTicket,
+    onSuccess: () => {
+      toast({
+        title: "تیکت شما ثبت شد",
+        description: "همکاران ما در سریع‌ترین زمان ممکن پاسخ خواهند داد.",
+      });
+      setTitle("");
+      setMessage("");
+      setPriority("NORMAL");
+      setFiles([]);
+      queryClient.invalidateQueries({ queryKey: ["supportTickets"] });
+    },
+    onError: (err: unknown) => {
+      const description = err instanceof Error ? err.message : "لطفاً دوباره تلاش کنید.";
+      toast({
+        variant: "destructive",
+        title: "خطا در ثبت تیکت",
+        description,
+      });
+    },
+  });
+
+  const sortedTickets = useMemo(() => {
+    if (!tickets) return [];
+    return [...tickets].sort((a, b) => {
+      const priorityDiff = priorityWeight[b.priority] - priorityWeight[a.priority];
+      if (priorityDiff !== 0) return priorityDiff;
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+  }, [tickets]);
+
+  const handleFileSelection = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const incomingFiles = Array.from(event.target.files ?? []);
+    if (incomingFiles.length === 0) return;
+
+    const exceedsLimit = files.length + incomingFiles.length > MAX_ATTACHMENTS;
+    if (exceedsLimit) {
+      toast({
+        variant: "destructive",
+        title: "حداکثر تعداد پیوست",
+        description: `امکان بارگذاری بیش از ${MAX_ATTACHMENTS} فایل وجود ندارد.`,
+      });
+    }
+
+    const allowed = incomingFiles.filter((file) => {
+      if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+        toast({
+          variant: "destructive",
+          title: "فرمت پشتیبانی نمی‌شود",
+          description: `${file.name} فرمت مجاز نیست.`,
+        });
+        return false;
+      }
+      return true;
+    });
+
+    const spaceLeft = MAX_ATTACHMENTS - files.length;
+    setFiles((prev) => [...prev, ...allowed.slice(0, spaceLeft)]);
+    event.target.value = "";
+  };
+
+  const removeFile = (index: number) => {
+    setFiles((prev) => prev.filter((_, idx) => idx !== index));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!title.trim() || !message.trim()) {
+      toast({
+        variant: "destructive",
+        title: "اطلاعات ناقص",
+        description: "لطفاً عنوان و متن پیام را کامل کنید.",
+      });
+      return;
+    }
+
+    setIsUploading(true);
+    let uploadedAttachments: TicketAttachmentPayload[] = [];
+    try {
+      uploadedAttachments = await Promise.all(files.map((file) => uploadAttachment(file)));
+    } catch (uploadError) {
+      const description = uploadError instanceof Error ? uploadError.message : "خطا در آپلود پیوست";
+      toast({
+        variant: "destructive",
+        title: "ارسال تیکت ناموفق بود",
+        description,
+      });
+      setIsUploading(false);
+      return;
+    }
+
+    try {
+      await createTicketMutation.mutateAsync({
+        title: title.trim(),
+        message: message.trim(),
+        priority,
+        attachments: uploadedAttachments,
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-3 text-center">
+        <h1 className="text-3xl font-bold text-journal">پشتیبانی روانیک</h1>
+        <p className="text-muted-foreground">
+          اگر سوال، مشکل یا پیشنهادی دارید، از این بخش برای ارتباط مستقیم با تیم پشتیبانی استفاده کنید.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>ارسال درخواست جدید</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div>
+              <label className="mb-2 block text-sm font-medium text-journal">عنوان تیکت</label>
+              <Input
+                placeholder="مثلاً مشکل در انتشار مقاله"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+              />
+            </div>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium text-journal">اولویت رسیدگی</label>
+              <Select value={priority} onValueChange={(value) => setPriority(value as SupportTicketPriorityKey)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="انتخاب اولویت" />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  {priorityOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      <div className="flex flex-col items-start">
+                        <span>{option.label}</span>
+                        <span className="text-xs text-muted-foreground">{option.description}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="mb-2 block text-sm font-medium text-journal">متن پیام</label>
+              <Textarea
+                rows={5}
+                placeholder="توضیح دهید چه مشکلی دارید یا چه انتظاری از تیم پشتیبانی دارید."
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-journal">پیوست (حداکثر {MAX_ATTACHMENTS} تصویر)</label>
+              <Input type="file" accept={ALLOWED_MIME_TYPES.join(",")} multiple onChange={handleFileSelection} />
+              {files.length > 0 && (
+                <ul className="space-y-1 text-sm">
+                  {files.map((file, index) => (
+                    <li key={`${file.name}-${index}`} className="flex items-center justify-between gap-4">
+                      <span className="truncate">
+                        {file.name} ({Math.max(1, Math.round(file.size / 1024))} کیلوبایت)
+                      </span>
+                      <Button type="button" variant="ghost" size="sm" onClick={() => removeFile(index)}>
+                        حذف
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div className="flex justify-end">
+              <Button type="submit" disabled={createTicketMutation.isPending || isUploading}>
+                {createTicketMutation.isPending || isUploading ? "در حال ارسال..." : "ثبت تیکت"}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-semibold text-journal">تیکت‌های شما</h2>
+          <span className="text-sm text-muted-foreground">
+            همه مکاتبات شما با تیم پشتیبانی در اینجا نمایش داده می‌شود.
+          </span>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+          </div>
+        ) : isError ? (
+          <Card>
+            <CardContent className="py-10 text-center text-destructive">
+              {error instanceof Error ? error.message : "دریافت تیکت‌ها با خطا مواجه شد."}
+            </CardContent>
+          </Card>
+        ) : sortedTickets.length === 0 ? (
+          <Card>
+            <CardContent className="py-10 text-center text-muted-foreground">
+              هنوز تیکتی ثبت نکرده‌اید.
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {sortedTickets.map((ticket) => (
+              <Card
+                key={ticket.id}
+                className={`border-r-4 ${
+                  ticket.priority === "HIGH"
+                    ? "border-red-500"
+                    : ticket.priority === "NORMAL"
+                    ? "border-amber-500"
+                    : "border-transparent"
+                }`}
+              >
+                <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <CardTitle className="text-lg">{ticket.title}</CardTitle>
+                    <p className="text-sm text-muted-foreground">
+                      {new Intl.DateTimeFormat("fa-IR", {
+                        dateStyle: "full",
+                        timeStyle: "short",
+                      }).format(new Date(ticket.createdAt))}
+                    </p>
+                  </div>
+                  <div className="flex flex-col items-start gap-2 md:items-end">
+                    <div className="flex items-center gap-2">
+                      <Badge className={priorityStyles[ticket.priority]}>{ticket.priorityLabel}</Badge>
+                      <Badge className={statusStyles[ticket.status]}>{ticket.statusLabel}</Badge>
+                    </div>
+                    <span className="text-xs text-muted-foreground">{priorityOptions.find((option) => option.value === ticket.priority)?.description}</span>
+                    <span className="text-xs text-muted-foreground">{statusDescriptions[ticket.status]}</span>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {ticket.messages.map((messageItem) => (
+                    <div
+                      key={messageItem.id}
+                      className={`rounded-lg border border-border p-4 ${
+                        messageItem.authorRole === "ADMIN" ? "bg-muted" : "bg-background"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-semibold text-journal">
+                          {messageItem.authorRole === "ADMIN" ? "پاسخ پشتیبانی" : "پیام شما"}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {new Intl.DateTimeFormat("fa-IR", {
+                            dateStyle: "short",
+                            timeStyle: "short",
+                          }).format(new Date(messageItem.createdAt))}
+                        </span>
+                      </div>
+                      <p className="mt-3 text-sm leading-7 text-journal-light">{messageItem.body}</p>
+                      {messageItem.attachments.length > 0 && (
+                        <div className="mt-3 space-y-2">
+                          <span className="text-xs font-medium text-muted-foreground">پیوست‌ها</span>
+                          <ul className="space-y-1 text-sm">
+                            {messageItem.attachments.map((attachment) => (
+                              <li key={attachment.id}>
+                                <a
+                                  href={attachment.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-primary underline-offset-2 hover:underline"
+                                >
+                                  {attachment.filename || "دانلود فایل"}
+                                </a>
+                                <span className="mr-2 text-xs text-muted-foreground">
+                                  ({Math.max(1, Math.round(attachment.size / 1024))} کیلوبایت)
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,59 @@
+import { cookies } from "next/headers";
+import { jwtVerify } from "jose";
+import { prisma } from "@/lib/prisma";
+
+export interface AdminSession {
+  id: number;
+  role: string;
+  name: string | null;
+  email: string;
+}
+
+const ADMIN_ROLE = "ADMIN" as const;
+
+export async function requireAdminSession(): Promise<AdminSession | null> {
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    return null;
+  }
+
+  try {
+    if (!process.env.JWT_SECRET) {
+      throw new Error("JWT_SECRET is not configured");
+    }
+
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(token, secret);
+
+    const userIdClaim = payload?.userId;
+    const userId =
+      typeof userIdClaim === "number"
+        ? userIdClaim
+        : typeof userIdClaim === "string"
+          ? Number.parseInt(userIdClaim, 10)
+          : undefined;
+
+    if (!userId || Number.isNaN(userId)) {
+      return null;
+    }
+
+    const adminUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        role: true,
+        name: true,
+        email: true,
+      },
+    });
+
+    if (!adminUser || adminUser.role !== ADMIN_ROLE) {
+      return null;
+    }
+
+    return adminUser;
+  } catch (error) {
+    console.error("ADMIN_SESSION_ERROR", error);
+    return null;
+  }
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,17 @@
+import { prisma } from "@/lib/prisma";
+
+export async function getNotificationsSnapshot(userId: number) {
+  const [notifications, unreadCount] = await Promise.all([
+    prisma.notification.findMany({
+      where: { userId },
+      include: {
+        actor: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    }),
+    prisma.notification.count({ where: { userId, isRead: false } }),
+  ]);
+
+  return { notifications, unreadCount };
+}

--- a/src/lib/reading-history.ts
+++ b/src/lib/reading-history.ts
@@ -1,0 +1,104 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+type RangeOption = "7d" | "30d" | "90d" | "365d" | "all";
+
+export interface ReadingHistoryFilters {
+  search?: string;
+  range?: RangeOption;
+  categoryId?: number;
+  limit?: number;
+}
+
+export interface ReadingHistoryEntry {
+  viewedAt: Date;
+  article: Prisma.ArticleGetPayload<{
+    include: {
+      author: { select: { name: true; avatarUrl: true } };
+      categories: { select: { name: true } };
+      _count: { select: { claps: true; comments: true } };
+    };
+  }>;
+}
+
+const resolveRange = (range?: RangeOption) => {
+  switch (range) {
+    case "7d":
+      return 7;
+    case "30d":
+      return 30;
+    case "90d":
+      return 90;
+    case "365d":
+      return 365;
+    default:
+      return undefined;
+  }
+};
+
+export async function getReadingHistoryEntries(
+  userId: number,
+  { search, range = "30d", categoryId, limit = 50 }: ReadingHistoryFilters = {}
+): Promise<ReadingHistoryEntry[]> {
+  const normalizedLimit = Math.min(Math.max(limit, 1), 200);
+  const days = resolveRange(range);
+
+  const where: Prisma.ReadingHistoryWhereInput = {
+    userId,
+  };
+
+  if (days) {
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+    where.viewedAt = { gte: since };
+  }
+
+  const articleFilters: Prisma.ArticleWhereInput = {};
+
+  if (search) {
+    const normalizedSearch = search.trim();
+    if (normalizedSearch.length > 0) {
+      articleFilters.OR = [
+        { title: { contains: normalizedSearch, mode: "insensitive" } },
+        { content: { contains: normalizedSearch, mode: "insensitive" } },
+        {
+          categories: {
+            some: { name: { contains: normalizedSearch, mode: "insensitive" } },
+          },
+        },
+      ];
+    }
+  }
+
+  if (categoryId) {
+    articleFilters.categories = {
+      some: { id: categoryId },
+    };
+  }
+
+  if (Object.keys(articleFilters).length > 0) {
+    where.article = {
+      ...articleFilters,
+    };
+  }
+
+  const history = await prisma.readingHistory.findMany({
+    where,
+    orderBy: { viewedAt: "desc" },
+    take: normalizedLimit,
+    include: {
+      article: {
+        include: {
+          author: { select: { name: true, avatarUrl: true } },
+          categories: { select: { name: true } },
+          _count: { select: { claps: true, comments: true } },
+        },
+      },
+    },
+  });
+
+  return history.map((entry) => ({
+    viewedAt: entry.viewedAt,
+    article: entry.article,
+  }));
+}

--- a/src/lib/support.ts
+++ b/src/lib/support.ts
@@ -1,0 +1,15 @@
+// src/lib/support.ts
+export const SUPPORT_STATUS_TEXTS = {
+  OPEN: "در انتظار پاسخ",
+  ANSWERED: "پاسخ داده شده",
+  CLOSED: "بسته شده",
+} as const;
+
+export const SUPPORT_PRIORITY_TEXTS = {
+  LOW: "کم",
+  NORMAL: "معمولی",
+  HIGH: "فوری",
+} as const;
+
+export type SupportTicketStatusKey = keyof typeof SUPPORT_STATUS_TEXTS;
+export type SupportTicketPriorityKey = keyof typeof SUPPORT_PRIORITY_TEXTS;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,8 +6,10 @@ export const config = {
   matcher: [
     '/profile/:path*',
     '/write/:path*',
+    '/support/:path*',
     '/admin/:path*',
-    '/api/admin/:path*'
+    '/api/admin/:path*',
+    '/api/support/:path*'
   ],
 };
 


### PR DESCRIPTION
## Summary
- enforce server-side attachment limits and type checks before accepting new support tickets
- add a simple per-user rate limiter to throttle rapid ticket submissions
- reuse the shared admin session guard in the stats stream endpoint instead of duplicating JWT parsing

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e12e9482a08332b1c5991f624d8ec7